### PR TITLE
Swaping CW20 for Juno no longer requires permission step

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react'
 import {
   swapNativeForToken,
   swapTokenForNative,
-  increaseTokenAllowance,
 } from 'services/swap'
 import TokenList from 'public/token_list.json'
 import { ToastContainer, toast } from 'react-toastify'

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -99,53 +99,6 @@ export default function Home() {
     setTokenAmount(tokenBPrice)
   }
 
-  const approveAllowance = async () => {
-    if (client == undefined) {
-      toast.error('Please connect wallet', {
-        position: 'top-right',
-        autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-      })
-      return
-    }
-    try {
-      setTransactionState('APPROVING_ALLOWANCE')
-      await increaseTokenAllowance({
-        tokenAmount: tokenAmount * 1000000,
-        senderAddress: address,
-        tokenAddress: tokenAInfo.token_address,
-        swapAddress: tokenAInfo.swap_address,
-        client,
-      })
-      toast.success('Permissions Succesful', {
-        position: 'top-right',
-        autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-      })
-      setTransactionState('ALLOWANCE_APPROVED')
-    } catch (e) {
-      toast.error(`Error with granting permissions ${e}`, {
-        position: 'top-right',
-        autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-      })
-      console.log(e)
-      setTransactionState('IDLE')
-    }
-  }
-
   // TODO don't hardwire everything, just for testing
   const handleSwap = async () => {
     if (!client) {
@@ -245,32 +198,11 @@ export default function Home() {
         />
 
         <section>
-          {tokenAName !== 'JUNO' && (
-            <>
-              <SwapButton
-                isLoading={transactionStatus === 'APPROVING_ALLOWANCE'}
-                isActive={transactionStatus === 'IDLE'}
-                onClick={approveAllowance}
-                label={`Allow Wasmswap to access your ${tokenAName}`}
-              />
-              {['EXECUTING_SWAP', 'ALLOWANCE_APPROVED'].includes(
-                transactionStatus
-              ) && (
-                <SwapButton
-                  isLoading={transactionStatus === 'EXECUTING_SWAP'}
-                  onClick={handleSwap}
-                  label="Swap"
-                />
-              )}
-            </>
-          )}
-          {tokenAName === 'JUNO' && (
             <SwapButton
               isLoading={transactionStatus === 'EXECUTING_SWAP'}
               onClick={handleSwap}
               label="Swap"
             />
-          )}
         </section>
       </SwapFormFrame>
       <Disclaimer delayMs={3000}>

--- a/services/swap.ts
+++ b/services/swap.ts
@@ -38,19 +38,6 @@ export const swapNativeForToken = async (input: swapNativeForTokenInput) => {
   return execute
 }
 
-export interface increaseTokenAllowanceInput {
-  tokenAmount: number
-  senderAddress: string
-  tokenAddress: string
-  swapAddress: string
-  client: SigningCosmWasmClient
-}
-
-export const increaseTokenAllowance = async (input: increaseTokenAllowanceInput) => {
-  console.log(input)
-  console.log("skipped")
-}
-
 export interface swapTokenForNativeInput {
   tokenAmount: number
   price: number

--- a/state/atoms/transactionAtoms.ts
+++ b/state/atoms/transactionAtoms.ts
@@ -2,8 +2,6 @@ import { atom } from 'recoil'
 
 type TransactionStatusType =
   | 'IDLE'
-  | 'APPROVING_ALLOWANCE'
-  | 'ALLOWANCE_APPROVED'
   | 'EXECUTING_SWAP'
 
 export const transactionStatusState = atom<TransactionStatusType>({


### PR DESCRIPTION
The increase allowance call necessary to give the swap permission for the cw20 is now executed as one transaction with the swap command. This makes for a less confusing user interface.