### PR TITLE
Enable ibc transfer with atom

### DIFF
--- a/.env
+++ b/.env
@@ -3,9 +3,9 @@ NEXT_PUBLIC_SITE_TITLE=WasmSwap
 NEXT_PUBLIC_LOGO_URL=/crab.png
 
 # Chain
-NEXT_PUBLIC_CHAIN_ID=lucina
+NEXT_PUBLIC_CHAIN_ID=juno-1
 NEXT_PUBLIC_CHAIN_NAME=Juno
 NEXT_PUBLIC_CHAIN_BECH32_PREFIX=juno
-NEXT_PUBLIC_CHAIN_RPC_ENDPOINT=https://rpc.juno.giansalex.dev/
-NEXT_PUBLIC_CHAIN_REST_ENDPOINT=https://lcd.juno.giansalex.dev/
+NEXT_PUBLIC_CHAIN_RPC_ENDPOINT=https://rpc-juno.itastakers.com
+NEXT_PUBLIC_CHAIN_REST_ENDPOINT=https://lcd-juno.itastakers.com
 NEXT_PUBLIC_STAKING_DENOM="ujuno"

--- a/components/TransferDialog/WalletCardWithInput.tsx
+++ b/components/TransferDialog/WalletCardWithInput.tsx
@@ -4,6 +4,7 @@ import { StyledHeader, StyledDivForBalance, WalletIcon } from './card.styles'
 import { TokenAmountInput } from '../TokenAmountInput'
 import { useTokenInfo } from '../../hooks/useTokenInfo'
 import { TransactionOrigin, TransactionType } from './types'
+import { useIBCAssetInfo } from 'hooks/useIBCAssetInfo'
 
 type WalletCardWithInputProps = {
   transactionType: TransactionType
@@ -24,7 +25,7 @@ export const WalletCardWithInput = ({
   onChange,
   walletAddress = 'No address found',
 }: WalletCardWithInputProps) => {
-  const tokenInfo = useTokenInfo(tokenSymbol)
+  const tokenInfo = useIBCAssetInfo(tokenSymbol)
   return (
     <CardWithSeparator
       contents={[

--- a/components/TransferDialog/index.tsx
+++ b/components/TransferDialog/index.tsx
@@ -74,10 +74,11 @@ export const TransferDialog = ({
   const {balance: ibcTokenMaxAvailableBalance} = useIBCTokenBalance(tokenInfo.denom)
   const walletAddressTransferringAssetsFrom = ibcAddress
 
+  const {balance: availableAssetBalanceOnChain} = useTokenBalance({native:true,denom:tokenInfo.juno_denom,token_address:"",chain_id:"",swap_address:"",symbol:"",name:"",decimals:1,logoURI:"",tags:[]});
+
   const {address, client} = useRecoilValue(walletState)
   const walletAddressTransferringAssetsTo =
     address
-  const availableAssetBalanceOnChain = 399
   const arbitrarySwapFee = 0.03 
 
   const ibcTransfer = async () => {
@@ -88,7 +89,9 @@ export const TransferDialog = ({
     if (transactionKind == 'deposit') {
       await ibcClient.sendIbcTokens(ibcAddress,address,{amount: (tokenAmount*1000000).toString(), denom: tokenInfo.denom},"transfer",tokenInfo.channel,undefined, timeout)
     } else if (transactionKind == 'withdraw') {
-      await sendIbcTokens(address,ibcAddress,{amount: (tokenAmount*1000000).toString(), denom: tokenInfo.denom},"transfer",tokenInfo.juno_channel,undefined, timeout, client.fees.send,'',client)
+      console.log(tokenAmount)
+      console.log(tokenAmount*1000000)
+      await sendIbcTokens(address,ibcAddress,{amount: (tokenAmount*1000000).toString(), denom: tokenInfo.juno_denom},"transfer",tokenInfo.juno_channel,undefined, timeout, client.fees.exec,'',client)
     }
   }
 
@@ -128,14 +131,14 @@ export const TransferDialog = ({
                 value={tokenAmount}
                 onChange={setTokenAmount}
                 tokenSymbol={tokenSymbol}
-                maxValue={ibcTokenMaxAvailableBalance}
+                maxValue={availableAssetBalanceOnChain}
                 walletAddress={walletAddressTransferringAssetsTo}
               />
               <WalletCardWithBalance
                 transactionType="incoming"
                 transactionOrigin="wallet"
                 walletAddress={walletAddressTransferringAssetsFrom}
-                balance={availableAssetBalanceOnChain}
+                balance={ibcTokenMaxAvailableBalance}
                 tokenName={tokenInfo.name}
               />
             </>

--- a/components/TransferDialog/index.tsx
+++ b/components/TransferDialog/index.tsx
@@ -12,8 +12,11 @@ import { useRecoilState, useRecoilValue } from 'recoil'
 import { ibcWalletState, walletState } from 'state/atoms/walletAtoms'
 import { useTokenBalance } from 'hooks/useTokenBalance'
 import { useIBCTokenBalance } from 'hooks/useIBCTokenBalance'
-import { Coin } from '@cosmjs/stargate'
+import { BroadcastTxResponse, Coin, MsgTransferEncodeObject, StdFee } from '@cosmjs/stargate'
 import Long from 'long'
+import { Height } from '@cosmjs/stargate/build/codec/ibc/core/client/v1/client'
+import { MsgTransfer } from '@cosmjs/stargate/build/codec/ibc/applications/transfer/v1/tx'
+import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate'
 
 type TransferDialogProps = {
   tokenSymbol: string
@@ -21,6 +24,37 @@ type TransferDialogProps = {
   isShowing: boolean
   onRequestClose: () => void
 }
+
+const sendIbcTokens = (
+    senderAddress: string,
+    recipientAddress: string,
+    transferAmount: Coin,
+    sourcePort: string,
+    sourceChannel: string,
+    timeoutHeight: Height | undefined,
+    /** timeout in seconds */
+    timeoutTimestamp: number | undefined,
+    fee: StdFee,
+    memo = "",
+    client: SigningCosmWasmClient
+  ): Promise<BroadcastTxResponse> => {
+    const timeoutTimestampNanoseconds = timeoutTimestamp
+      ? Long.fromNumber(timeoutTimestamp).multiply(1_000_000_000)
+      : undefined;
+    const transferMsg: MsgTransferEncodeObject = {
+      typeUrl: "/ibc.applications.transfer.v1.MsgTransfer",
+      value: MsgTransfer.fromPartial({
+        sourcePort: sourcePort,
+        sourceChannel: sourceChannel,
+        sender: senderAddress,
+        receiver: recipientAddress,
+        token: transferAmount,
+        timeoutHeight: timeoutHeight,
+        timeoutTimestamp: timeoutTimestampNanoseconds,
+      }),
+    };
+    return client.signAndBroadcast(senderAddress, [transferMsg], fee, memo);
+  }
 
 export const TransferDialog = ({
   tokenSymbol,
@@ -49,7 +83,13 @@ export const TransferDialog = ({
   const ibcTransfer = async () => {
     const time = new Date()
     console.log(time.getTime())
-    ibcClient.sendIbcTokens(ibcAddress,address,{amount: (tokenAmount*1000000).toString(), denom: tokenInfo.denom},"transfer","channel-207",undefined, time.getTime() + 600000)
+    const time_seconds = Math.floor(time.getTime() / 1000)
+    const timeout = time_seconds + 300
+    if (transactionKind == 'deposit') {
+      await ibcClient.sendIbcTokens(ibcAddress,address,{amount: (tokenAmount*1000000).toString(), denom: tokenInfo.denom},"transfer",tokenInfo.channel,undefined, timeout)
+    } else if (transactionKind == 'withdraw') {
+      await sendIbcTokens(address,ibcAddress,{amount: (tokenAmount*1000000).toString(), denom: tokenInfo.denom},"transfer",tokenInfo.juno_channel,undefined, timeout, client.fees.send,'',client)
+    }
   }
 
   return (
@@ -89,12 +129,12 @@ export const TransferDialog = ({
                 onChange={setTokenAmount}
                 tokenSymbol={tokenSymbol}
                 maxValue={tokenMaxAvailableBalance}
-                walletAddress={walletAddressTransferringAssetsFrom}
+                walletAddress={walletAddressTransferringAssetsTo}
               />
               <WalletCardWithBalance
                 transactionType="incoming"
                 transactionOrigin="wallet"
-                walletAddress={walletAddressTransferringAssetsTo}
+                walletAddress={walletAddressTransferringAssetsFrom}
                 balance={availableAssetBalanceOnChain}
                 tokenName={tokenInfo.name}
               />

--- a/components/TransferDialog/index.tsx
+++ b/components/TransferDialog/index.tsx
@@ -4,9 +4,9 @@ import { Text } from '../Text'
 import { WalletCardWithInput } from './WalletCardWithInput'
 import { WalletCardWithBalance } from './WalletCardWithBalance'
 import { Button } from '../Button'
-import { useTokenInfo } from '../../hooks/useTokenInfo'
 import { useState } from 'react'
 import { TransactionKind } from './types'
+import { useIBCAssetInfo } from 'hooks/useIBCAssetInfo'
 
 type TransferDialogProps = {
   tokenSymbol: string
@@ -24,7 +24,7 @@ export const TransferDialog = ({
   const capitalizedTransactionType =
     transactionKind === 'deposit' ? 'Deposit' : 'Withdraw'
 
-  const tokenInfo = useTokenInfo(tokenSymbol)
+  const tokenInfo = useIBCAssetInfo(tokenSymbol)
 
   const [tokenAmount, setTokenAmount] = useState(0)
   const tokenMaxAvailableBalance = 1000

--- a/components/TransferDialog/index.tsx
+++ b/components/TransferDialog/index.tsx
@@ -9,7 +9,9 @@ import { TransactionKind } from './types'
 import { useIBCAssetInfo } from 'hooks/useIBCAssetInfo'
 import { useConnectIBCWallet } from 'hooks/useConnectIBCWallet'
 import { useRecoilState, useRecoilValue } from 'recoil'
-import { ibcWalletState } from 'state/atoms/walletAtoms'
+import { ibcWalletState, walletState } from 'state/atoms/walletAtoms'
+import { useTokenBalance } from 'hooks/useTokenBalance'
+import { useIBCTokenBalance } from 'hooks/useIBCTokenBalance'
 
 type TransferDialogProps = {
   tokenSymbol: string
@@ -30,12 +32,13 @@ export const TransferDialog = ({
   const tokenInfo = useIBCAssetInfo(tokenSymbol)
 
   console.log('connected')
-  const { address, client} = useRecoilValue(ibcWalletState)
+  const { address: ibcAddress, client: ibcClient} = useRecoilValue(ibcWalletState)
 
   const [tokenAmount, setTokenAmount] = useState(0)
-  const tokenMaxAvailableBalance = 1000
-  const walletAddressTransferringAssetsFrom = address
+  const {balance: tokenMaxAvailableBalance} = useIBCTokenBalance(tokenInfo.denom)
+  const walletAddressTransferringAssetsFrom = ibcAddress
 
+  // const {address, client} = useRecoilValue(walletState)
   const walletAddressTransferringAssetsTo =
     'juno1uw6ls6y8du6d1uw6ls6y8du6d1uw6ls6y'
   const availableAssetBalanceOnChain = 399

--- a/components/TransferDialog/index.tsx
+++ b/components/TransferDialog/index.tsx
@@ -12,6 +12,8 @@ import { useRecoilState, useRecoilValue } from 'recoil'
 import { ibcWalletState, walletState } from 'state/atoms/walletAtoms'
 import { useTokenBalance } from 'hooks/useTokenBalance'
 import { useIBCTokenBalance } from 'hooks/useIBCTokenBalance'
+import { Coin } from '@cosmjs/stargate'
+import Long from 'long'
 
 type TransferDialogProps = {
   tokenSymbol: string
@@ -38,11 +40,17 @@ export const TransferDialog = ({
   const {balance: tokenMaxAvailableBalance} = useIBCTokenBalance(tokenInfo.denom)
   const walletAddressTransferringAssetsFrom = ibcAddress
 
-  // const {address, client} = useRecoilValue(walletState)
+  const {address, client} = useRecoilValue(walletState)
   const walletAddressTransferringAssetsTo =
-    'juno1uw6ls6y8du6d1uw6ls6y8du6d1uw6ls6y'
+    address
   const availableAssetBalanceOnChain = 399
-  const arbitrarySwapFee = 0.03
+  const arbitrarySwapFee = 0.03 
+
+  const ibcTransfer = async () => {
+    const time = new Date()
+    console.log(time.getTime())
+    ibcClient.sendIbcTokens(ibcAddress,address,{amount: (tokenAmount*1000000).toString(), denom: tokenInfo.denom},"transfer","channel-207",undefined, time.getTime() + 600000)
+  }
 
   return (
     <Dialog isShowing={isShowing} onRequestClose={onRequestClose}>
@@ -101,7 +109,7 @@ export const TransferDialog = ({
             ${arbitrarySwapFee.toFixed(2)}
           </Text>
         </StyledDivForFee>
-        <Button size="humongous">{capitalizedTransactionType}</Button>
+        <Button size="humongous" onClick={()=>ibcTransfer()}>{capitalizedTransactionType}</Button>
       </StyledContent>
     </Dialog>
   )

--- a/components/TransferDialog/index.tsx
+++ b/components/TransferDialog/index.tsx
@@ -7,6 +7,9 @@ import { Button } from '../Button'
 import { useState } from 'react'
 import { TransactionKind } from './types'
 import { useIBCAssetInfo } from 'hooks/useIBCAssetInfo'
+import { useConnectIBCWallet } from 'hooks/useConnectIBCWallet'
+import { useRecoilState, useRecoilValue } from 'recoil'
+import { ibcWalletState } from 'state/atoms/walletAtoms'
 
 type TransferDialogProps = {
   tokenSymbol: string
@@ -26,10 +29,12 @@ export const TransferDialog = ({
 
   const tokenInfo = useIBCAssetInfo(tokenSymbol)
 
+  console.log('connected')
+  const { address, client} = useRecoilValue(ibcWalletState)
+
   const [tokenAmount, setTokenAmount] = useState(0)
   const tokenMaxAvailableBalance = 1000
-  const walletAddressTransferringAssetsFrom =
-    'cosmos1uw6ls6y8du6d1uw6ls6y8du6d1uw6ls6y'
+  const walletAddressTransferringAssetsFrom = address
 
   const walletAddressTransferringAssetsTo =
     'juno1uw6ls6y8du6d1uw6ls6y8du6d1uw6ls6y'

--- a/components/TransferDialog/index.tsx
+++ b/components/TransferDialog/index.tsx
@@ -71,7 +71,7 @@ export const TransferDialog = ({
   const { address: ibcAddress, client: ibcClient} = useRecoilValue(ibcWalletState)
 
   const [tokenAmount, setTokenAmount] = useState(0)
-  const {balance: tokenMaxAvailableBalance} = useIBCTokenBalance(tokenInfo.denom)
+  const {balance: ibcTokenMaxAvailableBalance} = useIBCTokenBalance(tokenInfo.denom)
   const walletAddressTransferringAssetsFrom = ibcAddress
 
   const {address, client} = useRecoilValue(walletState)
@@ -108,7 +108,7 @@ export const TransferDialog = ({
                 value={tokenAmount}
                 onChange={setTokenAmount}
                 tokenSymbol={tokenSymbol}
-                maxValue={tokenMaxAvailableBalance}
+                maxValue={ibcTokenMaxAvailableBalance}
                 walletAddress={walletAddressTransferringAssetsFrom}
               />
               <WalletCardWithBalance
@@ -128,7 +128,7 @@ export const TransferDialog = ({
                 value={tokenAmount}
                 onChange={setTokenAmount}
                 tokenSymbol={tokenSymbol}
-                maxValue={tokenMaxAvailableBalance}
+                maxValue={ibcTokenMaxAvailableBalance}
                 walletAddress={walletAddressTransferringAssetsTo}
               />
               <WalletCardWithBalance

--- a/hooks/useConnectIBCWallet.ts
+++ b/hooks/useConnectIBCWallet.ts
@@ -1,19 +1,18 @@
-import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate'
+import { SigningStargateClient } from '@cosmjs/stargate'
 import { useSetRecoilState } from 'recoil'
 import { ibcWalletState } from '../state/atoms/walletAtoms'
 import { useIBCAssetInfo } from './useIBCAssetInfo'
 
-export const useConnectWallet = (assetSymbol: string) => {
+export const useConnectIBCWallet = (chainId: string) => {
   const setWalletState = useSetRecoilState(ibcWalletState)
   return async () => {
-    const assetInfo = useIBCAssetInfo(assetSymbol)
-    await (window as any).keplr?.experimentalSuggestChain()
-    const chainId = process.env.NEXT_PUBLIC_CHAIN_ID
+    console.log(chainId)
     await (window as any).keplr?.enable(chainId)
     const offlineSigner = await (window as any).getOfflineSigner(chainId)
-
-    const wasmChainClient = await SigningCosmWasmClient.connectWithSigner(
-      process.env.NEXT_PUBLIC_CHAIN_RPC_ENDPOINT,
+    console.log(offlineSigner);
+    console.log("hello");
+    const wasmChainClient = await SigningStargateClient.connectWithSigner(
+      "https://cosmoshub.validator.network:443",
       offlineSigner
     )
 

--- a/hooks/useConnectIBCWallet.ts
+++ b/hooks/useConnectIBCWallet.ts
@@ -1,0 +1,27 @@
+import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate'
+import { useSetRecoilState } from 'recoil'
+import { ibcWalletState } from '../state/atoms/walletAtoms'
+import { useIBCAssetInfo } from './useIBCAssetInfo'
+
+export const useConnectWallet = (assetSymbol: string) => {
+  const setWalletState = useSetRecoilState(ibcWalletState)
+  return async () => {
+    const assetInfo = useIBCAssetInfo(assetSymbol)
+    await (window as any).keplr?.experimentalSuggestChain()
+    const chainId = process.env.NEXT_PUBLIC_CHAIN_ID
+    await (window as any).keplr?.enable(chainId)
+    const offlineSigner = await (window as any).getOfflineSigner(chainId)
+
+    const wasmChainClient = await SigningCosmWasmClient.connectWithSigner(
+      process.env.NEXT_PUBLIC_CHAIN_RPC_ENDPOINT,
+      offlineSigner
+    )
+
+    const [{ address }] = await offlineSigner.getAccounts()
+
+    setWalletState({
+      address,
+      client: wasmChainClient,
+    })
+  }
+}

--- a/hooks/useConnectWallet.ts
+++ b/hooks/useConnectWallet.ts
@@ -11,6 +11,7 @@ export const useConnectWallet = () => {
     await (window as any).keplr?.enable(chainId)
     const offlineSigner = await (window as any).getOfflineSigner(chainId)
 
+    console.log(process.env.NEXT_PUBLIC_CHAIN_RPC_ENDPOINT)
     const wasmChainClient = await SigningCosmWasmClient.connectWithSigner(
       process.env.NEXT_PUBLIC_CHAIN_RPC_ENDPOINT,
       offlineSigner

--- a/hooks/useIBCAssetInfo.ts
+++ b/hooks/useIBCAssetInfo.ts
@@ -4,6 +4,7 @@ import IBCAssetList from '../public/ibc_assets.json'
 export type IBCAssetInfo = {
   name: String,
   symbol: String,
+  chain_id: String,
 }
 
 export const useIBCAssetInfo = (assetSymbol: string) => {

--- a/hooks/useIBCAssetInfo.ts
+++ b/hooks/useIBCAssetInfo.ts
@@ -5,6 +5,7 @@ export type IBCAssetInfo = {
   name: String,
   symbol: String,
   chain_id: String,
+  denom: String
 }
 
 export const useIBCAssetInfo = (assetSymbol: string) => {

--- a/hooks/useIBCAssetInfo.ts
+++ b/hooks/useIBCAssetInfo.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react'
+import IBCAssetList from '../public/ibc_assets.json'
+
+export type IBCAssetInfo = {
+  name: String,
+  symbol: String,
+}
+
+export const useIBCAssetInfo = (assetSymbol: string) => {
+  return useMemo(
+    () => IBCAssetList.tokens.find((x) => x.symbol === assetSymbol),
+    [assetSymbol]
+  )
+}

--- a/hooks/useIBCTokenBalance.tsx
+++ b/hooks/useIBCTokenBalance.tsx
@@ -1,0 +1,21 @@
+import { useRecoilValue } from 'recoil'
+import { ibcWalletState } from '../state/atoms/walletAtoms'
+import { useQuery } from 'react-query'
+
+export const useIBCTokenBalance = (denom:string) => {
+  const { address, client } = useRecoilValue(ibcWalletState)
+
+  const { data: balance = 0, isLoading } = useQuery(
+    [`tokenBalance/${denom}`, address],
+    async () => {
+        const coin = await client.getBalance(address, denom)
+        const amount = coin ? Number(coin.amount) : 0
+        return amount / 1000000
+    },
+    {
+      enabled: Boolean(address),
+    }
+  )
+
+  return { balance, isLoading }
+}

--- a/hooks/useTokenBalance.tsx
+++ b/hooks/useTokenBalance.tsx
@@ -4,14 +4,14 @@ import { CW20 } from '../services/cw20'
 import { TokenInfo } from './useTokenInfo'
 import { useQuery } from 'react-query'
 
-export const useTokenBalance = ({ symbol, token_address }: TokenInfo) => {
+export const useTokenBalance = ({ token_address, native, denom}: TokenInfo) => {
   const { address, client } = useRecoilValue(walletState)
 
   const { data: balance = 0, isLoading } = useQuery(
-    [`tokenBalance/${symbol}`, address, token_address],
+    [`tokenBalance/${denom}`, address, token_address],
     async () => {
-      if (symbol === 'JUNO') {
-        const coin = await client.getBalance(address, 'ujuno')
+      if (native) {
+        const coin = await client.getBalance(address, denom)
         const amount = coin ? Number(coin.amount) : 0
         return amount / 1000000
       }

--- a/hooks/useTokenInfo.ts
+++ b/hooks/useTokenInfo.ts
@@ -10,6 +10,8 @@ export type TokenInfo = {
   decimals: number
   logoURI: string
   tags: string[]
+  denom: string,
+  native: boolean,
 }
 
 export const useTokenInfo = (tokenSymbol: string) => {

--- a/pages/transfer/AssetCard.tsx
+++ b/pages/transfer/AssetCard.tsx
@@ -5,7 +5,7 @@ import { ArrowUpIcon, ArrowDownIcon } from '@heroicons/react/outline'
 import { Button } from '../../components/Button'
 import { CardWithSeparator } from '../../components/CardWithSeparator'
 import { IconWrapper } from '../../components/IconWrapper'
-import { useTokenInfo } from '../../hooks/useTokenInfo'
+import { useIBCAssetInfo } from 'hooks/useIBCAssetInfo'
 
 type AssetCardProps = {
   tokenSymbol: string
@@ -16,7 +16,7 @@ type AssetCardProps = {
 }
 
 export const AssetCard = ({ tokenSymbol, onActionClick }: AssetCardProps) => {
-  const { symbol, name } = useTokenInfo(tokenSymbol)
+  const { symbol, name } = useIBCAssetInfo(tokenSymbol)
 
   return (
     <CardWithSeparator
@@ -50,6 +50,7 @@ export const AssetCard = ({ tokenSymbol, onActionClick }: AssetCardProps) => {
           <StyledButtonsWrapper>
             <Button
               onClick={() => {
+                console.log(`deposit ${symbol}`)
                 onActionClick({
                   tokenSymbol: symbol,
                   actionType: 'deposit',

--- a/pages/transfer/AssetCard.tsx
+++ b/pages/transfer/AssetCard.tsx
@@ -75,7 +75,6 @@ export const AssetCard = ({ tokenSymbol, onActionClick }: AssetCardProps) => {
                 onActionClick({
                   tokenSymbol: symbol,
                   actionType: 'withdraw',
-                  connectIBCWallet: connectWallet
                 })
               }}
               size="small"

--- a/pages/transfer/AssetCard.tsx
+++ b/pages/transfer/AssetCard.tsx
@@ -6,17 +6,19 @@ import { Button } from '../../components/Button'
 import { CardWithSeparator } from '../../components/CardWithSeparator'
 import { IconWrapper } from '../../components/IconWrapper'
 import { useIBCAssetInfo } from 'hooks/useIBCAssetInfo'
+import { useConnectIBCWallet } from 'hooks/useConnectIBCWallet'
 
 type AssetCardProps = {
   tokenSymbol: string
   onActionClick: (args: {
     tokenSymbol: string
-    actionType: 'deposit' | 'withdraw'
+    actionType: 'deposit' | 'withdraw',
   }) => void
 }
 
 export const AssetCard = ({ tokenSymbol, onActionClick }: AssetCardProps) => {
-  const { symbol, name } = useIBCAssetInfo(tokenSymbol)
+  const { symbol, name, chain_id} = useIBCAssetInfo(tokenSymbol)
+  const connectWallet = useConnectIBCWallet(chain_id)
 
   return (
     <CardWithSeparator
@@ -51,6 +53,7 @@ export const AssetCard = ({ tokenSymbol, onActionClick }: AssetCardProps) => {
             <Button
               onClick={() => {
                 console.log(`deposit ${symbol}`)
+                connectWallet()
                 onActionClick({
                   tokenSymbol: symbol,
                   actionType: 'deposit',
@@ -68,9 +71,11 @@ export const AssetCard = ({ tokenSymbol, onActionClick }: AssetCardProps) => {
             </Button>
             <Button
               onClick={() => {
+                connectWallet()
                 onActionClick({
                   tokenSymbol: symbol,
                   actionType: 'withdraw',
+                  connectIBCWallet: connectWallet
                 })
               }}
               size="small"

--- a/pages/transfer/index.tsx
+++ b/pages/transfer/index.tsx
@@ -15,7 +15,7 @@ export default function Transfer() {
   ] = useReducer((store, updatedStore) => ({ ...store, ...updatedStore }), {
     transactionKind: 'deposit',
     isTransferDialogShowing: false,
-    selectedToken: 'JUNO',
+    selectedToken: 'ATOM',
   })
 
   function handleAssetCardActionClick({ actionType, tokenSymbol }) {
@@ -25,6 +25,7 @@ export default function Transfer() {
       isTransferDialogShowing: true,
     })
   }
+  console.log(selectedToken)
 
   return (
     <>
@@ -50,11 +51,11 @@ export default function Transfer() {
           </StyledSubtitle>
           <StyledGrid>
             <AssetCard
-              tokenSymbol="JUNO"
+              tokenSymbol="ATOM"
               onActionClick={handleAssetCardActionClick}
             />
             <AssetCard
-              tokenSymbol="JUNO"
+              tokenSymbol="UST"
               onActionClick={handleAssetCardActionClick}
             />
           </StyledGrid>

--- a/pages/transfer/index.tsx
+++ b/pages/transfer/index.tsx
@@ -7,6 +7,8 @@ import { Header } from './Header'
 import { AssetCard } from './AssetCard'
 import { spaces } from '../../util/constants'
 import { TransferDialog } from '../../components/TransferDialog'
+import { useIBCAssetInfo } from 'hooks/useIBCAssetInfo'
+import { useConnectIBCWallet } from 'hooks/useConnectIBCWallet'
 
 export default function Transfer() {
   const [
@@ -18,7 +20,7 @@ export default function Transfer() {
     selectedToken: 'ATOM',
   })
 
-  function handleAssetCardActionClick({ actionType, tokenSymbol }) {
+  function handleAssetCardActionClick({ actionType, tokenSymbol}) {
     updateState({
       transactionKind: actionType,
       selectedToken: tokenSymbol,

--- a/public/chain_info.ts
+++ b/public/chain_info.ts
@@ -1,12 +1,12 @@
 export const chainInfo = {
 	// Chain-id of the Cosmos SDK chain.
-	chainId: "lucina",
+	chainId: "juno-1",
 	// The name of the chain to be displayed to the user.
-	chainName: "Juno Testnet",
+	chainName: "Juno Mestnet",
 	// RPC endpoint of the chain.
-	rpc: "https://rpc.juno.giansalex.dev/" ,
+	rpc: "https://rpc-juno.itastakers.com",
 	// REST endpoint of the chain.
-	rest: "https://lcd.juno.giansalex.dev/",
+	rest: "https://lcd-juno.itastakers.com",
 	// Staking coin information
 	stakeCurrency: {
 	    // Coin denomination to be displayed to the user.

--- a/public/ibc_assets.json
+++ b/public/ibc_assets.json
@@ -1,0 +1,13 @@
+{
+    "tokens": [
+        {
+            "name":"ATOM",
+            "symbol": "ATOM"
+        },
+        {
+            "name":"UST",
+            "symbol":"UST"
+        }
+    ]
+
+}

--- a/public/ibc_assets.json
+++ b/public/ibc_assets.json
@@ -2,11 +2,13 @@
     "tokens": [
         {
             "name":"ATOM",
-            "symbol": "ATOM"
+            "symbol": "ATOM",
+            "chain_id": "cosmoshub-4"
         },
         {
             "name":"UST",
-            "symbol":"UST"
+            "symbol":"UST",
+            "chain_id":"terra-1"
         }
     ]
 

--- a/public/ibc_assets.json
+++ b/public/ibc_assets.json
@@ -4,13 +4,17 @@
             "name":"ATOM",
             "symbol": "ATOM",
             "chain_id": "cosmoshub-4",
-            "denom":"uatom"
+            "denom":"uatom",
+            "channel":"channel-207",
+            "juno_channel":"channel-1"
         },
         {
             "name":"UST",
             "symbol":"UST",
             "chain_id":"terra-1",
-            "denom":"uust"
+            "denom":"uust",
+            "channel":"info",
+            "juno_channel":"channel-7"
         }
     ]
 

--- a/public/ibc_assets.json
+++ b/public/ibc_assets.json
@@ -3,12 +3,14 @@
         {
             "name":"ATOM",
             "symbol": "ATOM",
-            "chain_id": "cosmoshub-4"
+            "chain_id": "cosmoshub-4",
+            "denom":"uatom"
         },
         {
             "name":"UST",
             "symbol":"UST",
-            "chain_id":"terra-1"
+            "chain_id":"terra-1",
+            "denom":"uust"
         }
     ]
 

--- a/public/ibc_assets.json
+++ b/public/ibc_assets.json
@@ -6,7 +6,8 @@
             "chain_id": "cosmoshub-4",
             "denom":"uatom",
             "channel":"channel-207",
-            "juno_channel":"channel-1"
+            "juno_channel":"channel-1",
+            "juno_denom":"ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
         },
         {
             "name":"UST",
@@ -14,7 +15,8 @@
             "chain_id":"terra-1",
             "denom":"uust",
             "channel":"info",
-            "juno_channel":"channel-7"
+            "juno_channel":"channel-7",
+            "juno_denom":"ibc/test"
         }
     ]
 

--- a/public/token_list.json
+++ b/public/token_list.json
@@ -18,7 +18,9 @@
       "name": "Juno",
       "decimals": 6,
       "logoURI": "",
-      "tags": ["native"]
+      "tags": ["native"],
+      "native":true,
+      "denom":"ujuno"
     },
     {
       "chain_id": "lucina",
@@ -28,7 +30,9 @@
       "name": "Poodle Coin",
       "decimals": 6,
       "logoURI": "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/29231450/Poodle-Standard-Gray-On-White-Standing.jpg",
-      "tags": ["memecoin"]
+      "tags": ["memecoin"],
+      "native":false,
+      "denom":"upood"
     },
     {
       "chain_id": "lucina",
@@ -38,7 +42,9 @@
       "name": "Crab Coin",
       "decimals": 6,
       "logoURI": "",
-      "tags": ["memecoin"] 
+      "tags": ["memecoin"],
+      "native":false,
+      "denom":"ucrab"
     },
     {
       "chain_id": "lucina",
@@ -48,7 +54,9 @@
       "name": "DAO Coin",
       "decimals": 6,
       "logoURI": "",
-      "tags": ["memecoin"] 
+      "tags": ["memecoin"],
+      "native":false,
+      "denom":"udao"
     }
   ],
   "version": {

--- a/state/atoms/walletAtoms.ts
+++ b/state/atoms/walletAtoms.ts
@@ -1,11 +1,24 @@
 import { atom } from 'recoil'
 import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate'
+import { SigningStargateClient } from '@cosmjs/stargate'
 
 export const walletState = atom<{
   client: SigningCosmWasmClient | null
   address: string
 }>({
   key: 'walletState',
+  default: {
+    client: null,
+    address: '',
+  },
+  dangerouslyAllowMutability: true,
+})
+
+export const ibcWalletState = atom<{
+  client: SigningStargateClient | null
+  address: string
+}>({
+  key: 'ibcWalletState',
   default: {
     client: null,
     address: '',


### PR DESCRIPTION
This PR adds an ibc asset list json and functionality for enabling IBC assets. It currently works to transfer main net atom to main net juno. 