### PR TITLE
Fix add max

### DIFF
--- a/features/liquidity/components/ManagePoolDialog/ManagePoolDialog.tsx
+++ b/features/liquidity/components/ManagePoolDialog/ManagePoolDialog.tsx
@@ -220,7 +220,7 @@ function AddLiquidityContent({
         onClick={handleApplyMaximumAmount}
         iconBefore={<PlusIcon />}
       >
-        Add maximum amount
+        Provide max liquidity
       </SecondaryButton>
     </StyledDivForContent>
   )

--- a/features/swap/components/ConvenienceBalanceButtons.tsx
+++ b/features/swap/components/ConvenienceBalanceButtons.tsx
@@ -2,14 +2,17 @@ import { Text } from '../../../components/Text'
 import React from 'react'
 import { styled } from '@stitches/react'
 import { StyledSecondaryButton } from '../../../components/Button'
+import { getBaseToken } from 'hooks/useTokenInfo'
 
 type ConvenienceBalanceButtonsProps = {
   disabled?: boolean
+  tokenSymbol: string
   availableAmount: number
   onChange: (amount: number) => void
 }
 
 export const ConvenienceBalanceButtons = ({
+  tokenSymbol,
   availableAmount,
   disabled,
   onChange,
@@ -17,7 +20,15 @@ export const ConvenienceBalanceButtons = ({
   return (
     !disabled && (
       <>
-        <StyledButton onClick={() => onChange(availableAmount)}>
+        <StyledButton
+          onClick={() => {
+            let amount =
+              tokenSymbol === getBaseToken().symbol
+                ? availableAmount - 0.025
+                : availableAmount
+            onChange(amount)
+          }}
+        >
           <Text type="subtitle" variant="light">
             Max
           </Text>

--- a/features/swap/components/TokenSelector.tsx
+++ b/features/swap/components/TokenSelector.tsx
@@ -50,6 +50,7 @@ export const TokenSelector = ({
           />
           {!isTokenListShowing && tokenSymbol && !readOnly && (
             <ConvenienceBalanceButtons
+              tokenSymbol={tokenSymbol}
               availableAmount={availableAmount}
               onChange={!disabled ? handleAmountChange : () => {}}
             />


### PR DESCRIPTION
Improve copy on add max liquidity dialogue and subtract fees from max available when token is the base token. 