### PR TITLE
Add liquidity slippage and IBC max button

### DIFF
--- a/features/assets/components/TransferDialog/WalletCardWithInput.tsx
+++ b/features/assets/components/TransferDialog/WalletCardWithInput.tsx
@@ -25,6 +25,8 @@ export const WalletCardWithInput = ({
   walletAddress = 'No address found',
 }: WalletCardWithInputProps) => {
   const tokenInfo = useIBCAssetInfo(tokenSymbol)
+  // TODO: Configure max fee per chain
+  const maxFee = 0.05
   return (
     <CardWithSeparator
       contents={[
@@ -58,7 +60,7 @@ export const WalletCardWithInput = ({
           <TokenAmountInput
             amount={value}
             onAmountChange={onChange}
-            maxAmount={maxValue}
+            maxAmount={Math.max(maxValue - maxFee, 0)}
             tokenSymbol={tokenInfo.symbol}
           />
         </>,

--- a/features/assets/components/TransferDialog/index.tsx
+++ b/features/assets/components/TransferDialog/index.tsx
@@ -104,7 +104,7 @@ export const TransferDialog = ({
       <StyledContent>
         <Text variant="header">{capitalizedTransactionType}</Text>
         <Text css={{ paddingTop: '$12', paddingBottom: '$9' }} variant="body">
-          How many {tokenInfo.name} would you like to {transactionKind}?
+          How much {tokenInfo.name} would you like to {transactionKind}?
         </Text>
         <StyledDivForCards>
           {transactionKind === 'deposit' && (

--- a/features/liquidity/components/ManagePoolDialog/usePoolDialogController.ts
+++ b/features/liquidity/components/ManagePoolDialog/usePoolDialogController.ts
@@ -36,7 +36,9 @@ export const usePoolDialogController = ({
   })
 
   function calculateMaxApplicableBalances() {
-    const tokenAToTokenBRatio = reserve?.[0] / reserve?.[1]
+    // TODO: Make slippage configurable
+    const slippage = 0.99
+    const tokenAToTokenBRatio = (reserve?.[0] * slippage) / reserve?.[1]
     const tokenABalanceMinusGasFee = Math.max(tokenABalance - 0.1, 0)
 
     const isTokenALimitingFactor =


### PR DESCRIPTION
This PR adds a 1% slippage tolerance by default when adding liquidity. It also subtracts 0.05 max gas fee amount from the maximum you can deposit or withdraw via IBC.