### PR TITLE
Update Transfers list UI & implement Token selector for the dialog

### DIFF
--- a/components/Layout/AppLayout.tsx
+++ b/components/Layout/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { styled } from '../theme'
 import { NavigationSidebar } from './NavigationSidebar'
 import { FooterBar } from './FooterBar'
+import { APP_MAX_WIDTH } from 'util/constants'
 
 export const AppLayout = ({
   navigationSidebar = <NavigationSidebar />,
@@ -8,16 +9,17 @@ export const AppLayout = ({
   children,
 }) => {
   return (
-    <>
-      <StyledWrapper>
-        {navigationSidebar}
-        <StyledContainer>
-          <main>{children}</main>
-          {footerBar}
-        </StyledContainer>
+    <StyledWrapper>
+      {navigationSidebar}
+      <StyledContainer>
+        <main>{children}</main>
+        {footerBar}
+      </StyledContainer>
+
+      <StyledWrapperForSpring>
         <StyledSpringBottom src="/springs-bg.png" />
-      </StyledWrapper>
-    </>
+      </StyledWrapperForSpring>
+    </StyledWrapper>
   )
 }
 
@@ -26,6 +28,8 @@ const StyledWrapper = styled('div', {
   minHeight: '100vh',
   gridTemplateColumns: '18rem 1fr',
   backgroundColor: '$backgroundColors$base',
+  maxWidth: APP_MAX_WIDTH,
+  margin: '0 auto',
 })
 
 const StyledContainer = styled('div', {
@@ -38,6 +42,17 @@ const StyledContainer = styled('div', {
   '& main': {
     maxWidth: '44rem',
   },
+})
+
+const StyledWrapperForSpring = styled('div', {
+  left: '50%',
+  top: '50%',
+  transform: 'translate(-50%, -50%)',
+  position: 'fixed',
+  width: '100%',
+  maxWidth: APP_MAX_WIDTH,
+  height: '100vh',
+  zIndex: '$1',
 })
 
 const StyledSpringBottom = styled('img', {

--- a/components/Layout/NavigationSidebar.tsx
+++ b/components/Layout/NavigationSidebar.tsx
@@ -153,13 +153,13 @@ const StyledWrapper = styled('div', {
   backgroundColor: '$backgroundColors$base',
   overflow: 'auto',
   borderRight: '1px solid $borderColors$inactive',
-
   position: 'sticky',
   top: 0,
   left: 0,
   width: '100%',
   height: '100%',
   maxHeight: '100vh',
+  zIndex: '$2',
 })
 
 const StyledMenuContainer = styled('div', {

--- a/components/Toast/Toast.tsx
+++ b/components/Toast/Toast.tsx
@@ -75,7 +75,7 @@ const StyledButtonForCloseButton = styled(Button, {
   position: 'absolute',
   right: '$space$4',
   top: '$space$4',
-  '& svg': { color: '$white50' },
+  '& svg': { color: '$iconColors$default' },
 })
 
 const StyledDivForButtons = styled('div', {

--- a/components/TokenSelectList.tsx
+++ b/components/TokenSelectList.tsx
@@ -1,0 +1,135 @@
+import { styled } from 'components/theme'
+import { TokenInfo } from 'hooks/useTokenList'
+import { Text } from 'components/Text'
+import { formatTokenBalance } from 'util/conversion'
+import { useTokenBalance } from 'hooks/useTokenBalance'
+import { useIBCTokenBalance } from '../hooks/useIBCTokenBalance'
+import { ButtonForWrapper } from './Button'
+import { ComponentPropsWithoutRef } from 'react'
+import { Spinner } from './Spinner'
+
+type TokenSelectList = {
+  activeTokenSymbol?: string
+  tokenList: Array<Pick<TokenInfo, 'symbol' | 'logoURI' | 'name'>>
+  onSelect: (tokenSymbol: string) => void
+  fetchingBalanceMode: 'native' | 'ibc'
+  visibleNumberOfTokensInViewport?: number
+}
+
+const StyledDivForWrapper = styled('div', {
+  overflowY: 'scroll',
+})
+
+export const TokenSelectList = ({
+  activeTokenSymbol,
+  tokenList,
+  onSelect,
+  fetchingBalanceMode = 'native',
+  visibleNumberOfTokensInViewport = 5.5,
+  ...props
+}: TokenSelectList & ComponentPropsWithoutRef<typeof StyledDivForWrapper>) => {
+  return (
+    <StyledDivForWrapper
+      {...props}
+      css={{
+        maxHeight: `${visibleNumberOfTokensInViewport * 3.5}rem`,
+        ...(props.css ? props.css : {}),
+      }}
+    >
+      {tokenList?.map((tokenInfo) => {
+        return (
+          <StyledButtonForRow
+            role="listitem"
+            variant="ghost"
+            key={tokenInfo.symbol}
+            selected={tokenInfo.symbol === activeTokenSymbol}
+            onClick={() => {
+              onSelect(tokenInfo.symbol)
+            }}
+          >
+            <StyledDivForColumn kind="token">
+              <StyledImgForTokenLogo
+                as={tokenInfo.logoURI ? 'img' : 'div'}
+                src={tokenInfo.logoURI}
+                alt={tokenInfo.symbol}
+              />
+              <div data-token-info="">
+                <Text variant="body">{tokenInfo.symbol}</Text>
+                <Text variant="caption" color="disabled">
+                  {tokenInfo.name}
+                </Text>
+              </div>
+            </StyledDivForColumn>
+            <StyledDivForColumn kind="balance">
+              <Text variant="body">
+                {fetchingBalanceMode === 'native' && (
+                  <FetchBalanceTextForNativeTokenSymbol
+                    tokenSymbol={tokenInfo.symbol}
+                  />
+                )}
+                {fetchingBalanceMode === 'ibc' && (
+                  <FetchBalanceTextForIbcTokenSymbol
+                    tokenSymbol={tokenInfo.symbol}
+                  />
+                )}
+              </Text>
+              <Text variant="caption" color="disabled">
+                available
+              </Text>
+            </StyledDivForColumn>
+          </StyledButtonForRow>
+        )
+      })}
+    </StyledDivForWrapper>
+  )
+}
+
+const FetchBalanceTextForNativeTokenSymbol = ({ tokenSymbol }) => {
+  const { balance, isLoading } = useTokenBalance(tokenSymbol)
+  return (
+    <>{isLoading ? <Spinner size={16} /> : formatTokenBalance(balance || 0)}</>
+  )
+}
+
+const FetchBalanceTextForIbcTokenSymbol = ({ tokenSymbol }) => {
+  const { balance, isLoading } = useIBCTokenBalance(tokenSymbol)
+  return (
+    <>{isLoading ? <Spinner size={16} /> : formatTokenBalance(balance || 0)}</>
+  )
+}
+
+const StyledButtonForRow = styled(ButtonForWrapper, {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '$4 $6 !important',
+  userSelect: 'none',
+  cursor: 'pointer',
+  marginBottom: '$2',
+  '&:last-child': {
+    marginBottom: 0,
+  },
+})
+
+const StyledDivForColumn = styled('div', {
+  display: 'grid',
+  variants: {
+    kind: {
+      token: {
+        columnGap: '$space$6',
+        gridTemplateColumns: '30px 1fr',
+        alignItems: 'center',
+      },
+      balance: {
+        textAlign: 'right',
+      },
+    },
+  },
+})
+
+const StyledImgForTokenLogo = styled('img', {
+  width: '30px',
+  height: '30px',
+  borderRadius: '50%',
+  backgroundColor: '#ccc',
+})

--- a/components/theme/theme.ts
+++ b/components/theme/theme.ts
@@ -44,7 +44,9 @@ const baseTheme = {
     1: '6px',
     2: '8px',
   },
-  shadows: {},
+  shadows: {
+    light: '0px $space$1 $space$3 0px $colors$black15',
+  },
   zIndices: {
     1: 0,
     2: 1,

--- a/components/theme/themeAtom.ts
+++ b/components/theme/themeAtom.ts
@@ -8,5 +8,5 @@ export enum AppTheme {
 
 export const themeAtom = atom<AppTheme>({
   key: '@theme',
-  default: AppTheme.light,
+  default: __DARK_MODE_ENABLED_BY_DEFAULT__ ? AppTheme.dark : AppTheme.light,
 })

--- a/components/theme/themeAtom.ts
+++ b/components/theme/themeAtom.ts
@@ -8,5 +8,5 @@ export enum AppTheme {
 
 export const themeAtom = atom<AppTheme>({
   key: '@theme',
-  default: __DARK_MODE_ENABLED_BY_DEFAULT__ ? AppTheme.dark : AppTheme.light,
+  default: AppTheme.light,
 })

--- a/features/assets/components/AssetsList.tsx
+++ b/features/assets/components/AssetsList.tsx
@@ -30,8 +30,8 @@ export const AssetsList = ({ onActionClick }) => {
     <>
       {__TRANSFERS_ENABLED__ && (
         <StyledGrid>
-          <Text variant="primary" css={{ paddingBottom: '$4' }}>
-            My tokens
+          <Text variant="primary" css={{ paddingBottom: '$12' }}>
+            My assets
           </Text>
           {isLoading ? (
             <AssetCard state={AssetCardState.fetching} />
@@ -68,11 +68,11 @@ export const AssetsList = ({ onActionClick }) => {
       <Text
         variant="primary"
         css={{
-          paddingTop: !__TRANSFERS_ENABLED__ ? '0' : '$19',
-          paddingBottom: !__TRANSFERS_ENABLED__ ? '$6' : '$10',
+          paddingTop: !__TRANSFERS_ENABLED__ ? '0' : '$16',
+          paddingBottom: !__TRANSFERS_ENABLED__ ? '$6' : '$12',
         }}
       >
-        All tokens
+        Other tokens
       </Text>
       <StyledGrid>
         {__TRANSFERS_ENABLED__ && isLoading ? (
@@ -98,7 +98,15 @@ export const AssetsList = ({ onActionClick }) => {
           </>
         )}
       </StyledGrid>
-      <Text variant="caption" css={{ paddingTop: '$12' }}>
+      <Text
+        variant="caption"
+        align="center"
+        color="disabled"
+        css={{
+          padding: '$16 0',
+          borderBottom: '1px solid $borderColors$inactive',
+        }}
+      >
         More tokens available soon
       </Text>
     </>

--- a/features/assets/components/AssetsList.tsx
+++ b/features/assets/components/AssetsList.tsx
@@ -48,14 +48,14 @@ export const AssetsList = ({ onActionClick }) => {
                   />
                 ))}
               {isConnected && !hasTransferredAssets && (
-                <Text variant="body" color="secondary" as="span">
+                <Text variant="body" as="span">
                   No IBC assets... yet!
                 </Text>
               )}
               {!isConnected && !isLoading && (
                 <Text variant="body">
                   Connect your wallet{' '}
-                  <Text variant="body" color="secondary" as="span">
+                  <Text variant="body" as="span">
                     to see your tokens.
                   </Text>
                 </Text>

--- a/features/assets/components/TransferDialog/AssetSelector.tsx
+++ b/features/assets/components/TransferDialog/AssetSelector.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { styled } from 'components/theme'
 import { useIBCAssetInfo } from 'hooks/useIBCAssetInfo'
 import { Text } from 'components/Text'
@@ -6,41 +7,96 @@ import { ImageForTokenLogo } from 'components/ImageForTokenLogo'
 import { useIBCTokenBalance } from 'hooks/useIBCTokenBalance'
 import { formatTokenBalance } from 'util/conversion'
 import { Button, ButtonForWrapper } from 'components/Button'
-import { Valid } from 'icons/Valid'
+import { Union } from 'icons/Union'
+import { Chevron } from 'icons/Chevron'
+import { TokenOptionsList } from './TokenOptionsList'
+import { Spinner } from 'components/Spinner'
+import { useTokenBalance } from 'hooks/useTokenBalance'
 
-export const AssetSelector = ({ tokenSymbol }) => {
-  const assetInfo = useIBCAssetInfo(tokenSymbol)
-  const { balance: ibcTokenMaxAvailableBalance } =
-    useIBCTokenBalance(tokenSymbol)
+type AssetSelectorProps = {
+  activeTokenSymbol: string
+  onTokenSymbolSelect: (tokenSymbol: string) => void
+  fetchingBalancesAgainstChain: 'ibc' | 'native'
+}
+
+export const AssetSelector = ({
+  activeTokenSymbol,
+  onTokenSymbolSelect,
+  fetchingBalancesAgainstChain,
+}: AssetSelectorProps) => {
+  const assetInfo = useIBCAssetInfo(activeTokenSymbol)
+  const {
+    balance: ibcTokenMaxAvailableBalance,
+    isLoading: externalBalanceIsLoading,
+  } = useIBCTokenBalance(activeTokenSymbol)
+  const {
+    balance: nativeMaxAvailableBalance,
+    isLoading: nativeBalanceIsLoading,
+  } = useTokenBalance(activeTokenSymbol)
+
+  const maxBalance =
+    fetchingBalancesAgainstChain === 'ibc'
+      ? ibcTokenMaxAvailableBalance
+      : nativeMaxAvailableBalance
+  const isLoading =
+    fetchingBalancesAgainstChain === 'ibc'
+      ? externalBalanceIsLoading
+      : nativeBalanceIsLoading
+
+  const [isTokenListOpen, setTokenListOpen] = useState(false)
+
+  function handleToggleList() {
+    setTokenListOpen(!isTokenListOpen)
+  }
 
   return (
-    <StyledButtonForWrapper variant="secondary">
-      <StyledDivForTokenContent>
-        <ImageForTokenLogo
-          size="big"
-          logoURI={assetInfo.logoURI}
-          alt={tokenSymbol}
-        />
-        <div>
-          <Text variant="body">{tokenSymbol}</Text>
-          <Text variant="secondary">
-            {formatTokenBalance(ibcTokenMaxAvailableBalance)} available
-          </Text>
-        </div>
-      </StyledDivForTokenContent>
-
-      <Button
-        variant="secondary"
-        icon={
-          <IconWrapper
-            size="16px"
-            // rotation="-90deg"
-            color="tertiary"
-            icon={<Valid />}
+    <>
+      <StyledButtonForWrapper variant="secondary" onClick={handleToggleList}>
+        <StyledDivForTokenContent>
+          <ImageForTokenLogo
+            size="big"
+            logoURI={assetInfo.logoURI}
+            alt={activeTokenSymbol}
           />
-        }
-      />
-    </StyledButtonForWrapper>
+          <div>
+            <Text variant="body">{activeTokenSymbol}</Text>
+            <Text variant="secondary">
+              {formatTokenBalance(maxBalance)} available
+            </Text>
+          </div>
+        </StyledDivForTokenContent>
+
+        <Button
+          variant="ghost"
+          onClick={handleToggleList}
+          icon={
+            <IconWrapper
+              size="16px"
+              rotation="-90deg"
+              color="tertiary"
+              icon={
+                isLoading ? (
+                  <Spinner size={16} />
+                ) : (
+                  <>{isTokenListOpen ? <Union /> : <Chevron />}</>
+                )
+              }
+            />
+          }
+        />
+      </StyledButtonForWrapper>
+      {isTokenListOpen && (
+        <TokenOptionsList
+          activeTokenSymbol={activeTokenSymbol}
+          fetchingBalanceMode={fetchingBalancesAgainstChain}
+          onSelect={(tokenSymbol) => {
+            onTokenSymbolSelect(tokenSymbol)
+            setTokenListOpen(false)
+          }}
+          css={{ padding: '$1 0 $12' }}
+        />
+      )}
+    </>
   )
 }
 

--- a/features/assets/components/TransferDialog/TokenOptionsList.tsx
+++ b/features/assets/components/TransferDialog/TokenOptionsList.tsx
@@ -1,0 +1,21 @@
+import { TokenSelectList } from 'components/TokenSelectList'
+import { useIBCAssetList } from 'hooks/useIbcAssetList'
+
+export const TokenOptionsList = ({
+  activeTokenSymbol,
+  onSelect,
+  fetchingBalanceMode,
+  ...props
+}) => {
+  const [tokenList] = useIBCAssetList()
+  return (
+    <TokenSelectList
+      {...props}
+      tokenList={tokenList.tokens}
+      activeTokenSymbol={activeTokenSymbol}
+      onSelect={onSelect}
+      visibleNumberOfTokensInViewport={2.5}
+      fetchingBalanceMode={fetchingBalanceMode}
+    />
+  )
+}

--- a/features/assets/components/TransferDialog/WalletInfo.tsx
+++ b/features/assets/components/TransferDialog/WalletInfo.tsx
@@ -2,13 +2,11 @@ import { styled } from 'components/theme'
 import { Text } from 'components/Text'
 import { ConnectIcon } from 'icons/Connect'
 import { useRecoilValue } from 'recoil'
-import {
-  ibcWalletState,
-  walletState,
-} from '../../../../state/atoms/walletAtoms'
-import { IconWrapper } from '../../../../components/IconWrapper'
-import { Logo } from '../../../../icons/Logo'
+import { ibcWalletState, walletState } from 'state/atoms/walletAtoms'
+import { IconWrapper } from 'components/IconWrapper'
+import { Logo } from 'icons/Logo'
 import { CSS } from '@stitches/react'
+import { APP_NAME } from 'util/constants'
 
 export const WalletInfo = ({ label, icon, address, css }) => {
   return (
@@ -51,7 +49,7 @@ export const AppWalletInfo = ({ css, depositing }: WalletInfoProps) => {
   return (
     <WalletInfo
       css={css}
-      label={`${depositing ? 'To ' : ''}${process.env.NEXT_PUBLIC_SITE_TITLE}`}
+      label={`${depositing ? 'To ' : ''}${APP_NAME}`}
       icon={<IconWrapper color="secondary" size="32px" icon={<Logo />} />}
       address={walletAddress}
     />

--- a/features/assets/components/TransferDialog/WalletInfo.tsx
+++ b/features/assets/components/TransferDialog/WalletInfo.tsx
@@ -29,28 +29,29 @@ export const WalletInfo = ({ label, icon, address, css }) => {
 
 type WalletInfoProps = {
   css?: CSS
+  depositing?: boolean
 }
 
-export const KeplrWalletInfo = ({ css }: WalletInfoProps) => {
+export const KeplrWalletInfo = ({ css, depositing }: WalletInfoProps) => {
   const { address: ibcWalletAddress } = useRecoilValue(ibcWalletState)
 
   return (
     <WalletInfo
       css={css}
-      label="Keplr wallet"
+      label={`${depositing ? 'To ' : ''}Keplr wallet`}
       icon={<StyledImgForIcon src="/img/keplr-icon.png" alt="Keplr wallet" />}
       address={ibcWalletAddress}
     />
   )
 }
 
-export const AppWalletInfo = ({ css }: WalletInfoProps) => {
+export const AppWalletInfo = ({ css, depositing }: WalletInfoProps) => {
   const { address: walletAddress } = useRecoilValue(walletState)
 
   return (
     <WalletInfo
       css={css}
-      label={`To ${process.env.NEXT_PUBLIC_SITE_TITLE}`}
+      label={`${depositing ? 'To ' : ''}${process.env.NEXT_PUBLIC_SITE_TITLE}`}
       icon={<IconWrapper color="secondary" size="32px" icon={<Logo />} />}
       address={walletAddress}
     />

--- a/features/swap/components/TokenOptionsList.tsx
+++ b/features/swap/components/TokenOptionsList.tsx
@@ -1,108 +1,15 @@
-import { styled } from 'components/theme'
 import { useTokenList } from 'hooks/useTokenList'
-import { Text } from 'components/Text'
-import { formatTokenBalance } from 'util/conversion'
-import { useTokenBalance } from 'hooks/useTokenBalance'
+import { TokenSelectList } from '../../../components/TokenSelectList'
 
-export const TokenOptionsList = ({ activeTokenSymbol, onSelect }) => {
+export const TokenOptionsList = ({ activeTokenSymbol, onSelect, ...props }) => {
   const [tokenList] = useTokenList()
   return (
-    <>
-      {tokenList?.tokens.map((tokenInfo) => {
-        return (
-          <StyledDivForRow
-            role="listitem"
-            key={tokenInfo.symbol}
-            active={tokenInfo.symbol === activeTokenSymbol}
-            onClick={() => {
-              onSelect(tokenInfo.symbol)
-            }}
-          >
-            <StyledDivForColumn kind="token">
-              <StyledImgForTokenLogo
-                as={tokenInfo.logoURI ? 'img' : 'div'}
-                src={tokenInfo.logoURI}
-                alt={tokenInfo.symbol}
-              />
-              <div data-token-info="">
-                <Text variant="body">{tokenInfo.symbol}</Text>
-                <Text variant="caption" color="disabled">
-                  {tokenInfo.name}
-                </Text>
-              </div>
-            </StyledDivForColumn>
-            <StyledDivForColumn kind="balance">
-              <Text variant="body">
-                <FetchBalanceTextForTokenSymbol
-                  tokenSymbol={tokenInfo.symbol}
-                />
-              </Text>
-              <Text variant="caption" color="disabled">
-                available
-              </Text>
-            </StyledDivForColumn>
-          </StyledDivForRow>
-        )
-      })}
-    </>
+    <TokenSelectList
+      {...props}
+      tokenList={tokenList.tokens}
+      activeTokenSymbol={activeTokenSymbol}
+      onSelect={onSelect}
+      fetchingBalanceMode="native"
+    />
   )
 }
-
-const FetchBalanceTextForTokenSymbol = ({ tokenSymbol }) => {
-  const { balance } = useTokenBalance(tokenSymbol)
-  return <>{formatTokenBalance(balance || 0)}</>
-}
-
-const StyledDivForRow = styled('div', {
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  padding: '8px 12px',
-  borderRadius: '6px',
-  userSelect: 'none',
-  cursor: 'pointer',
-  transition: 'background-color 0.1s ease-out',
-  marginBottom: 5,
-  '&:hover': {
-    backgroundColor: '$colors$dark10',
-  },
-  '&:active': {
-    backgroundColor: '$colors$dark05',
-  },
-  '&:last-child': {
-    marginBottom: 0,
-  },
-  variants: {
-    active: {
-      true: {
-        backgroundColor: '$colors$dark05',
-      },
-      false: {
-        backgroundColor: '$colors$dark0',
-      },
-    },
-  },
-})
-
-const StyledDivForColumn = styled('div', {
-  display: 'grid',
-  variants: {
-    kind: {
-      token: {
-        columnGap: '$space$6',
-        gridTemplateColumns: '30px 1fr',
-        alignItems: 'center',
-      },
-      balance: {
-        textAlign: 'right',
-      },
-    },
-  },
-})
-
-const StyledImgForTokenLogo = styled('img', {
-  width: '30px',
-  height: '30px',
-  borderRadius: '50%',
-  backgroundColor: '#ccc',
-})

--- a/features/swap/components/TokenSelector.tsx
+++ b/features/swap/components/TokenSelector.tsx
@@ -100,15 +100,14 @@ export const TokenSelector = ({
         />
       </StyledDivForWrapper>
       {isTokenListShowing && (
-        <StyledDivForTokensListWrapper>
-          <TokenOptionsList
-            activeTokenSymbol={tokenSymbol}
-            onSelect={(selectedTokenSymbol) => {
-              onChange({ tokenSymbol: selectedTokenSymbol, amount })
-              setTokenListShowing(false)
-            }}
-          />
-        </StyledDivForTokensListWrapper>
+        <TokenOptionsList
+          activeTokenSymbol={tokenSymbol}
+          onSelect={(selectedTokenSymbol) => {
+            onChange({ tokenSymbol: selectedTokenSymbol, amount })
+            setTokenListShowing(false)
+          }}
+          css={{ padding: '$1 $6 $12' }}
+        />
       )}
     </StyledDivForContainer>
   )
@@ -136,10 +135,6 @@ const StyledDivForAmountWrapper = styled('div', {
   justifyContent: 'flex-end',
   position: 'relative',
   zIndex: 1,
-})
-
-const StyledDivForTokensListWrapper = styled('div', {
-  padding: '$1 $6 $12',
 })
 
 const StyledDivForOverlay = styled('div', {

--- a/hooks/useIBCTokenBalance.tsx
+++ b/hooks/useIBCTokenBalance.tsx
@@ -1,47 +1,40 @@
 import { useRecoilValue } from 'recoil'
-import { ibcWalletState, WalletStatusType } from '../state/atoms/walletAtoms'
+import { walletState } from '../state/atoms/walletAtoms'
 import { useQuery } from 'react-query'
 import { getIBCAssetInfo } from './useIBCAssetInfo'
 import { DEFAULT_TOKEN_BALANCE_REFETCH_INTERVAL } from '../util/constants'
 import { convertMicroDenomToDenom } from 'util/conversion'
-
-const useGetWalletStatus = () => {
-  const walletValue = useRecoilValue(ibcWalletState)
-
-  return {
-    isConnecting:
-      walletValue.status === WalletStatusType.connecting ||
-      walletValue.status === WalletStatusType.restored,
-    isConnected: walletValue.status === WalletStatusType.connected,
-  }
-}
+import { SigningStargateClient } from '@cosmjs/stargate'
 
 export const useIBCTokenBalance = (tokenSymbol) => {
-  const {
-    address,
-    tokenSymbol: connectedTokenSymbol,
-    client,
-  } = useRecoilValue(ibcWalletState)
-
-  const { isConnecting, isConnected } = useGetWalletStatus()
-
-  const enabled = isConnected && connectedTokenSymbol === tokenSymbol
+  const { address: nativeWalletAddress } = useRecoilValue(walletState)
 
   const { data: balance = 0, isLoading } = useQuery(
-    [`ibcTokenBalance/${tokenSymbol}`, address],
+    [`ibcTokenBalance/${tokenSymbol}`, nativeWalletAddress],
     async () => {
-      const { denom, decimals } = getIBCAssetInfo(tokenSymbol)
-      const coin = await client.getBalance(address, denom)
+      const { denom, decimals, chain_id, rpc } = getIBCAssetInfo(tokenSymbol)
+
+      await window.keplr.enable(chain_id)
+      const offlineSigner = await window.getOfflineSigner(chain_id)
+
+      const wasmChainClient = await SigningStargateClient.connectWithSigner(
+        rpc,
+        offlineSigner
+      )
+
+      const [{ address }] = await offlineSigner.getAccounts()
+      const coin = await wasmChainClient.getBalance(address, denom)
+
       const amount = coin ? Number(coin.amount) : 0
       return convertMicroDenomToDenom(amount, decimals)
     },
     {
-      enabled,
+      enabled: Boolean(nativeWalletAddress),
       refetchOnMount: 'always',
       refetchInterval: DEFAULT_TOKEN_BALANCE_REFETCH_INTERVAL,
       refetchIntervalInBackground: true,
     }
   )
 
-  return { balance, enabled, isLoading: isLoading || isConnecting }
+  return { balance, isLoading: isLoading }
 }

--- a/pages/transfer/index.tsx
+++ b/pages/transfer/index.tsx
@@ -33,6 +33,12 @@ export default function Transfer() {
     })
   }
 
+  function handleUpdateSelectedToken(tokenSymbol: string) {
+    updateState({
+      selectedToken: tokenSymbol,
+    })
+  }
+
   function handleTransferDialogClose() {
     updateState({ isTransferDialogShowing: false })
   }
@@ -118,6 +124,7 @@ export default function Transfer() {
           tokenSymbol={selectedToken}
           transactionKind={transactionKind}
           isShowing={isTransferDialogShowing}
+          onTokenSelect={handleUpdateSelectedToken}
           onRequestClose={handleTransferDialogClose}
         />
       )}

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -29,6 +29,7 @@ export const SLIPPAGE_OPTIONS = [0.01, 0.02, 0.03, 0.05]
 export const NETWORK_FEE = 0.003
 
 export const APP_NAME = process.env.NEXT_PUBLIC_SITE_TITLE
+export const APP_MAX_WIDTH = '1920px'
 
 /* the app operates in test mode */
 export const __TEST_MODE__ = !JSON.parse(


### PR DESCRIPTION
This updates the asset lists UI to match up the designs better and allows makes the transfer dialog much more sophisticated. Now, you can select another asset right in the dialog, and it will also fetch balances on native chain or on external chain depending the transaction kind. Sick stuff!