### PR TITLE
Fix rounding error

### DIFF
--- a/features/liquidity/components/ManagePoolDialog/usePoolDialogController.tsx
+++ b/features/liquidity/components/ManagePoolDialog/usePoolDialogController.tsx
@@ -145,7 +145,7 @@ const useMutateLiquidity = ({
             convertDenomToMicroDenom(tokenAAmount, tokenA.decimals)
           ),
           nativeDenom: tokenA.denom,
-          maxToken: Math.floor(
+          maxToken: Math.ceil(
             convertDenomToMicroDenom(tokenBAmount, tokenB.decimals)
           ),
           minLiquidity: 0,


### PR DESCRIPTION
This number should round up as the contract always rounds up to avoid beind underfunded. This will cause issues if user is adding very small amounts of liquidity.