### PR TITLE
Fixes for rewards and staking

### DIFF
--- a/features/liquidity/hooks/usePoolTokensDollarValue.ts
+++ b/features/liquidity/hooks/usePoolTokensDollarValue.ts
@@ -62,8 +62,8 @@ export const usePoolTokensDollarValue = ({
     return [
       getPoolTokensDollarValue({ swapInfo, tokenAmountInMicroDenom }),
       isLoading || !enabled,
-    ]
+    ] as const
   }
 
-  return [0, isLoading || !enabled]
+  return [0, isLoading || !enabled] as const
 }

--- a/features/liquidity/hooks/useStakingClaims.ts
+++ b/features/liquidity/hooks/useStakingClaims.ts
@@ -19,7 +19,7 @@ export const useStakingClaims = ({ poolId }) => {
 
   const { data = {} as StakingClaimsType, isLoading } =
     useQuery<StakingClaimsType>(
-      `@staking-claims/${poolId}`,
+      `@staking-claims/${poolId}/${address}`,
       async () => {
         const claims = await getClaims(address, pool.staking_address, client)
 

--- a/hooks/useRewardsQueries.ts
+++ b/hooks/useRewardsQueries.ts
@@ -90,7 +90,7 @@ export const useClaimRewards = ({ pool, ...options }: UseClaimRewardsArgs) => {
     async () => {
       const hasPendingRewards =
         __POOL_REWARDS_ENABLED__ &&
-        pendingRewards?.find(({ dollarValue }) => dollarValue > 0)
+        pendingRewards?.find(({ tokenAmount }) => tokenAmount > 0)
 
       const shouldBeAbleToClaimRewards = pool && client && hasPendingRewards
 
@@ -104,7 +104,7 @@ export const useClaimRewards = ({ pool, ...options }: UseClaimRewardsArgs) => {
               ({ tokenInfo }) => token.symbol === tokenInfo.symbol
             )
 
-            return pendingRewardsForToken.dollarValue > 0
+            return pendingRewardsForToken.tokenAmount > 0
           })
           .map(({ rewards_address }) => rewards_address)
 

--- a/hooks/useRewardsQueries.ts
+++ b/hooks/useRewardsQueries.ts
@@ -103,7 +103,7 @@ export const useClaimRewards = ({ pool, ...options }: UseClaimRewardsArgs) => {
             const pendingRewardsForToken = pendingRewards.find(
               ({ tokenInfo }) => token.symbol === tokenInfo.symbol
             )
-            console.log({ pendingRewardsForToken })
+
             return pendingRewardsForToken.dollarValue > 0
           })
           .map(({ rewards_address }) => rewards_address)


### PR DESCRIPTION
This is to validate rewards token contracts before claiming rewards to make sure the transaction doesn't fail in case if there's no rewards accumulated for a given token.

This also makes staking claims list & pending rewards queries refetch when user's wallet state change. Eg wallet was disconnected or changed.