### PR TITLE
Mobile toasts adoption

### DIFF
--- a/features/swap/hooks/useTokenSwap.tsx
+++ b/features/swap/hooks/useTokenSwap.tsx
@@ -2,6 +2,7 @@ import { useTokenInfo } from 'hooks/useTokenInfo'
 import {
   Button,
   ErrorIcon,
+  formatSdkErrorMessage,
   IconWrapper,
   Toast,
   UpRightArrow,
@@ -20,6 +21,7 @@ import { convertDenomToMicroDenom } from 'util/conversion'
 
 import { useRefetchQueries } from '../../../hooks/useRefetchQueries'
 import { useQueryMatchingPoolForSwap } from '../../../queries/useQueryMatchingPoolForSwap'
+import { formatCompactNumber } from '../../../util/formatCompactNumber'
 import { slippageAtom, tokenSwapAtom } from '../swapAtoms'
 
 type UseTokenSwapArgs = {
@@ -103,9 +105,27 @@ export const useTokenSwap = ({
       onSuccess() {
         toast.custom((t) => (
           <Toast
-            icon={<IconWrapper icon={<Valid />} color="valid" />}
-            title="Swap successful!"
+            icon={<IconWrapper icon={<Valid />} color="primary" />}
+            title="Swap successful"
+            body={`Turned ${formatCompactNumber(
+              providedTokenAmount,
+              'tokenAmount'
+            )} ${tokenA.symbol} to ${formatCompactNumber(
+              tokenToTokenPrice,
+              'tokenAmount'
+            )} ${tokenB.symbol}`}
             onClose={() => toast.dismiss(t.id)}
+            buttons={
+              <Button
+                as="a"
+                variant="ghost"
+                href={process.env.NEXT_PUBLIC_FEEDBACK_LINK}
+                target="__blank"
+                iconRight={<UpRightArrow />}
+              >
+                Provide feedback
+              </Button>
+            }
           />
         ))
 
@@ -120,12 +140,7 @@ export const useTokenSwap = ({
         refetchQueries()
       },
       onError(e) {
-        const errorMessage =
-          String(e).length > 300
-            ? `${String(e).substring(0, 150)} ... ${String(e).substring(
-                String(e).length - 150
-              )}`
-            : String(e)
+        const errorMessage = formatSdkErrorMessage(e)
 
         toast.custom((t) => (
           <Toast

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "focus-visible": "^5.2.0",
     "gsap": "^3.7.1",
-    "junoblocks": "^0.2.2",
+    "junoblocks": "^0.2.3",
     "next": "12.1.0",
     "normalize.css": "^8.0.1",
     "react": "^17.0.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,8 +5,11 @@ import 'focus-visible'
 import { ErrorBoundary } from 'components/ErrorBoundary'
 import { TestnetDialog } from 'components/TestnetDialog'
 import {
+  css,
   globalCss,
+  media,
   styled,
+  useMedia,
   useSubscribeDefaultAppTheme,
   useThemeClassName,
 } from 'junoblocks'
@@ -24,6 +27,14 @@ const applyGlobalStyles = globalCss({
     backgroundColor: '$backgroundColors$base',
   },
 })
+
+const toasterClassName = css({
+  [media.sm]: {
+    width: '100%',
+    padding: 0,
+    bottom: '$6 !important',
+  },
+}).toString()
 
 function NextJsAppRoot({ children }) {
   const themeClassName = useThemeClassName()
@@ -56,6 +67,7 @@ const StyledContentWrapper = styled('div', {
 })
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const isSmallScreen = useMedia('sm')
   return (
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>
@@ -63,7 +75,12 @@ function MyApp({ Component, pageProps }: AppProps) {
           <ErrorBoundary>
             <Component {...pageProps} />
             {__TEST_MODE__ && <TestnetDialog />}
-            <Toaster position="top-right" toastOptions={{ duration: 10000 }} />
+            <Toaster
+              position={isSmallScreen ? 'bottom-center' : 'top-right'}
+              toastOptions={{ duration: 1000000 }}
+              containerClassName={toasterClassName}
+              containerStyle={isSmallScreen ? { inset: 0 } : undefined}
+            />
           </ErrorBoundary>
         </NextJsAppRoot>
       </QueryClientProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,10 +2296,10 @@ json5@^1.0.1:
     array-includes "^3.1.4"
     object.assign "^4.1.2"
 
-junoblocks@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/junoblocks/-/junoblocks-0.2.2.tgz#1a1c6b9d8e1f529a41163189dfe1dc5278dcd07a"
-  integrity sha512-1JOLiPNjwvKeALeW35NHiiV7gtXUncWlepp8/QHHtllyQgNjmkxSRWrnZpR/oTtyDFN+4rTiY50hYZtsDNlAtg==
+junoblocks@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/junoblocks/-/junoblocks-0.2.3.tgz#a31ac719a8fbbdf1cbfb5a892df29c2b05f40e61"
+  integrity sha512-pb5UJ397kSOZDgtmbgq9NY7GSW9PPMPE3u2QFVtxEPuvdCGqJlbarTUB0FhYrqNfoCUUOUGi24EJgHhX9akCHg==
 
 language-subtag-registry@~0.3.2:
   version "0.3.21"


### PR DESCRIPTION
### What I'm doing
This is to update junoblocks version to include mobile toasts update and its integration. 

Additionally, this renders swap information in the toast and makes use of the `formatSdkErrorMessage` when rendering error toasts in the swap module.

### [See toasts ui update in the pr](https://github.com/sashimi36/junoblocks/pull/31)