### PR TITLE
Protect `useGetTokenDollarValueQuery` in case if token price is `undefined`

### DIFF
--- a/queries/useGetTokenDollarValueQuery.ts
+++ b/queries/useGetTokenDollarValueQuery.ts
@@ -1,13 +1,15 @@
-/*
- * takes base token price, fetches the ratio of the token provided vs the base token
- * and calculates the dollar value of the provided token
- * */
+import { protectAgainstNaN } from 'junoblocks'
+
 import { useCosmWasmClient } from '../hooks/useCosmWasmClient'
 import { useTokenDollarValue } from '../hooks/useTokenDollarValue'
 import { useBaseTokenInfo } from '../hooks/useTokenInfo'
 import { tokenToTokenPriceQueryWithPools } from './tokenToTokenPriceQuery'
 import { useGetQueryMatchingPoolForSwap } from './useQueryMatchingPoolForSwap'
 
+/*
+ * takes base token price, fetches the ratio of the token provided vs the base token
+ * and calculates the dollar value of the provided token
+ * */
 export const useGetTokenDollarValueQuery = () => {
   const tokenA = useBaseTokenInfo()
   const client = useCosmWasmClient()
@@ -22,17 +24,19 @@ export const useGetTokenDollarValueQuery = () => {
     async function getTokenDollarValue({ tokenInfo, tokenAmountInDenom }) {
       if (!tokenAmountInDenom) return 0
 
-      const { price: priceForOneToken } = await tokenToTokenPriceQueryWithPools(
-        {
+      const priceForOneToken = (
+        await tokenToTokenPriceQueryWithPools({
           matchingPools: getMatchingPoolForSwap({ tokenA, tokenB: tokenInfo }),
           tokenA,
           tokenB: tokenInfo,
           client,
           amount: 1,
-        }
-      )
+        })
+      )?.price
 
-      return (tokenAmountInDenom / priceForOneToken) * tokenADollarPrice
+      return protectAgainstNaN(
+        (tokenAmountInDenom / priceForOneToken) * tokenADollarPrice
+      )
     },
     Boolean(
       tokenA && client && !fetchingDollarPrice && !isLoadingPoolForSwapMatcher


### PR DESCRIPTION
This is to cover the use case when a pool is not yet created and thereby there's no way to figure out a given token price. The dollar price query relies on token to token price query and this is to protect the query against that use case.