### PR TITLE
Don't include rewards tokens in the token list

### DIFF
--- a/features/liquidity/components/LiquidityRewardsCard.tsx
+++ b/features/liquidity/components/LiquidityRewardsCard.tsx
@@ -146,8 +146,8 @@ export const LiquidityRewardsCard = ({
             ))}
           {pendingRewardsRenderedInline?.map(({ tokenInfo, tokenAmount }) => (
             <UnderlyingAssetRow
-              key={tokenInfo.symbol}
-              tokenSymbol={tokenInfo.symbol}
+              key={tokenInfo?.symbol}
+              tokenInfo={tokenInfo}
               tokenAmount={tokenAmount}
             />
           ))}

--- a/features/liquidity/components/ManageLiquidityCard.tsx
+++ b/features/liquidity/components/ManageLiquidityCard.tsx
@@ -93,14 +93,8 @@ export const ManageLiquidityCard = ({
           Underlying assets
         </Text>
         <Column gap={6} css={{ paddingBottom: '$16' }}>
-          <UnderlyingAssetRow
-            tokenSymbol={tokenA.symbol}
-            tokenAmount={tokenAReserve}
-          />
-          <UnderlyingAssetRow
-            tokenSymbol={tokenB.symbol}
-            tokenAmount={tokenBReserve}
-          />
+          <UnderlyingAssetRow tokenInfo={tokenA} tokenAmount={tokenAReserve} />
+          <UnderlyingAssetRow tokenInfo={tokenB} tokenAmount={tokenBReserve} />
         </Column>
         <Inline css={{ paddingBottom: '$12' }}>
           {didProvideLiquidity && (

--- a/features/liquidity/components/UnderlyingAssetRow.tsx
+++ b/features/liquidity/components/UnderlyingAssetRow.tsx
@@ -1,5 +1,4 @@
 import { useTokenDollarValue } from 'hooks/useTokenDollarValue'
-import { useTokenInfo } from 'hooks/useTokenInfo'
 import {
   Button,
   dollarValueFormatterWithDecimals,
@@ -12,20 +11,22 @@ import {
   Tooltip,
 } from 'junoblocks'
 
+import { TokenInfo } from '../../../queries/usePoolsListQuery'
+
 type UnderlyingAssetRowProps = {
-  tokenSymbol?: string
+  tokenInfo?: TokenInfo
   tokenAmount?: number
   visible?: boolean
 }
 
 export const UnderlyingAssetRow = ({
-  tokenSymbol,
+  tokenInfo,
   tokenAmount,
   visible = true,
 }: UnderlyingAssetRowProps) => {
-  const token = useTokenInfo(visible ? tokenSymbol : undefined)
+  const token = visible ? tokenInfo : undefined
   const [tokenDollarValue] = useTokenDollarValue(
-    visible ? tokenSymbol : undefined
+    visible ? tokenInfo?.symbol : undefined
   )
 
   const tokenAmountDollarValue = dollarValueFormatterWithDecimals(
@@ -46,14 +47,14 @@ export const UnderlyingAssetRow = ({
           logoURI={token?.logoURI}
           alt={token?.symbol}
         />
-        <Text variant="link">{tokenSymbol}</Text>
+        <Text variant="link">{token?.symbol}</Text>
       </Inline>
       <Inline align="center" gap={4}>
         <Inline gap={6}>
           <Text variant="body">
             {formatTokenBalance(tokenAmount, { includeCommaSeparation: true })}
           </Text>
-          <Text variant="secondary">{tokenSymbol}</Text>
+          <Text variant="secondary">{token?.symbol}</Text>
         </Inline>
         <Tooltip label={infoTooltipLabel} aria-label={infoTooltipLabel}>
           <Button

--- a/hooks/useRewardsQueries.ts
+++ b/hooks/useRewardsQueries.ts
@@ -32,14 +32,15 @@ export const usePendingRewards = ({ pool }: UsePendingRewardsArgs) => {
     async () => {
       if (shouldQueryRewards) {
         return await Promise.all(
-          pool.rewards_tokens.map(async ({ rewards_address, decimals }) => {
+          pool.rewards_tokens.map(async (rewardsToken) => {
+            const { rewards_address, decimals } = rewardsToken
             const { pending_rewards, denom } = await getPendingRewards(
               address,
               rewards_address,
               client
             )
 
-            const tokenInfo = getTokenInfoByDenom({ denom })
+            const tokenInfo = getTokenInfoByDenom({ denom }) || rewardsToken
             const tokenAmount = convertMicroDenomToDenom(
               Number(pending_rewards),
               decimals ?? tokenInfo.decimals

--- a/hooks/useTokenList.ts
+++ b/hooks/useTokenList.ts
@@ -17,12 +17,8 @@ export const useTokenList = () => {
     () => {
       const tokenMapBySymbol = new Map()
       poolsListResponse.pools.forEach(({ pool_assets, rewards_tokens }) => {
-        pool_assets.forEach((token) => {
-          if (!tokenMapBySymbol.has(token.symbol)) {
-            tokenMapBySymbol.set(token.symbol, token)
-          }
-        })
-        rewards_tokens.forEach((token) => {
+        const poolTokens = [...(pool_assets || []), ...(rewards_tokens || [])]
+        poolTokens.forEach((token) => {
           if (!tokenMapBySymbol.has(token.symbol)) {
             tokenMapBySymbol.set(token.symbol, token)
           }

--- a/hooks/useTokenList.ts
+++ b/hooks/useTokenList.ts
@@ -16,9 +16,17 @@ export const useTokenList = () => {
     '@token-list',
     () => {
       const tokenMapBySymbol = new Map()
-      poolsListResponse.pools.forEach(({ pool_assets, rewards_tokens }) => {
-        const poolAssets = [...(pool_assets || []), ...(rewards_tokens || [])]
-        poolAssets.forEach((token) => {
+      /* serialize pool assets first */
+      poolsListResponse.pools.forEach(({ pool_assets }) => {
+        pool_assets?.forEach((token) => {
+          if (!tokenMapBySymbol.has(token.symbol)) {
+            tokenMapBySymbol.set(token.symbol, token)
+          }
+        })
+      })
+      /* add unique rewards tokens if any */
+      poolsListResponse.pools.forEach(({ rewards_tokens }) => {
+        rewards_tokens?.forEach((token) => {
           if (!tokenMapBySymbol.has(token.symbol)) {
             tokenMapBySymbol.set(token.symbol, token)
           }

--- a/hooks/useTokenList.ts
+++ b/hooks/useTokenList.ts
@@ -16,17 +16,9 @@ export const useTokenList = () => {
     '@token-list',
     () => {
       const tokenMapBySymbol = new Map()
-      /* serialize pool assets first */
+      /* serialize pool assets */
       poolsListResponse.pools.forEach(({ pool_assets }) => {
         pool_assets?.forEach((token) => {
-          if (!tokenMapBySymbol.has(token.symbol)) {
-            tokenMapBySymbol.set(token.symbol, token)
-          }
-        })
-      })
-      /* add unique rewards tokens if any */
-      poolsListResponse.pools.forEach(({ rewards_tokens }) => {
-        rewards_tokens?.forEach((token) => {
           if (!tokenMapBySymbol.has(token.symbol)) {
             tokenMapBySymbol.set(token.symbol, token)
           }

--- a/hooks/useTokenList.ts
+++ b/hooks/useTokenList.ts
@@ -16,8 +16,13 @@ export const useTokenList = () => {
     '@token-list',
     () => {
       const tokenMapBySymbol = new Map()
-      poolsListResponse.pools.forEach(({ pool_assets }) => {
+      poolsListResponse.pools.forEach(({ pool_assets, rewards_tokens }) => {
         pool_assets.forEach((token) => {
+          if (!tokenMapBySymbol.has(token.symbol)) {
+            tokenMapBySymbol.set(token.symbol, token)
+          }
+        })
+        rewards_tokens.forEach((token) => {
           if (!tokenMapBySymbol.has(token.symbol)) {
             tokenMapBySymbol.set(token.symbol, token)
           }

--- a/hooks/useTokenList.ts
+++ b/hooks/useTokenList.ts
@@ -17,8 +17,8 @@ export const useTokenList = () => {
     () => {
       const tokenMapBySymbol = new Map()
       poolsListResponse.pools.forEach(({ pool_assets, rewards_tokens }) => {
-        const poolTokens = [...(pool_assets || []), ...(rewards_tokens || [])]
-        poolTokens.forEach((token) => {
+        const poolAssets = [...(pool_assets || []), ...(rewards_tokens || [])]
+        poolAssets.forEach((token) => {
           if (!tokenMapBySymbol.has(token.symbol)) {
             tokenMapBySymbol.set(token.symbol, token)
           }


### PR DESCRIPTION
This is a follow up to the previous fix to resolve the issue where the unique rewards tokens are listed in the swap machine. Serialized rewards tokens will be now rendered directly from rewards config.