### PR TITLE
Price Impact UI

### DIFF
--- a/features/liquidity/components/ManagePoolDialog/TokenToTokenRates.tsx
+++ b/features/liquidity/components/ManagePoolDialog/TokenToTokenRates.tsx
@@ -17,14 +17,18 @@ export const TokenToTokenRates = ({
     tokenBSymbol,
   })
 
-  const { isShowing, conversionRate, conversionRateInDollar, tokenBSwapValueUSD } =
-    useTxRates({
-      tokenASymbol,
-      tokenBSymbol,
-      tokenAAmount,
-      tokenToTokenPrice: oneTokenToTokenPrice * tokenAAmount,
-      isLoading,
-    })
+  const {
+    isShowing,
+    conversionRate,
+    conversionRateInDollar,
+    tokenBSwapValueUSD,
+  } = useTxRates({
+    tokenASymbol,
+    tokenBSymbol,
+    tokenAAmount,
+    tokenToTokenPrice: oneTokenToTokenPrice * tokenAAmount,
+    isLoading,
+  })
 
   return (
     <StyledDivForGrid active={isShowing}>

--- a/features/liquidity/components/ManagePoolDialog/TokenToTokenRates.tsx
+++ b/features/liquidity/components/ManagePoolDialog/TokenToTokenRates.tsx
@@ -17,7 +17,7 @@ export const TokenToTokenRates = ({
     tokenBSymbol,
   })
 
-  const { isShowing, conversionRate, conversionRateInDollar, dollarValue } =
+  const { isShowing, conversionRate, conversionRateInDollar, tokenBSwapValueUSD } =
     useTxRates({
       tokenASymbol,
       tokenBSymbol,
@@ -37,7 +37,7 @@ export const TokenToTokenRates = ({
       </Text>
       <Text variant="caption" color="disabled">
         $
-        {dollarValueFormatterWithDecimals(dollarValue * 2, {
+        {dollarValueFormatterWithDecimals(tokenBSwapValueUSD * 2, {
           includeCommaSeparation: true,
         })}
       </Text>

--- a/features/swap/components/TransactionTips.tsx
+++ b/features/swap/components/TransactionTips.tsx
@@ -9,6 +9,7 @@ import {
   Inline,
   styled,
   Text,
+  Tooltip,
 } from 'junoblocks'
 import React, { useState } from 'react'
 import { useRecoilValue } from 'recoil'
@@ -132,33 +133,37 @@ export const TransactionTips = ({
           </Text>
         )}
       </StyledDivForRateWrapper>
-      <Inline justifyContent={'flex-end'} gap={8}>
-        <Inline
-          css={{
-            backgroundColor: errorThreshold
-              ? '$backgroundColors$error'
-              : '$backgroundColors$secondary',
-            padding: '$2 $4 $2 $2',
-            borderRadius: 4,
-          }}
-        >
-          <ArrowUpIcon
-            color={errorThreshold ? 'error' : 'secondary'}
-            css={{ transform: priceImpact < 0 ? 'rotate(180deg)' : undefined }}
-            size="medium"
-          />
-          <Text
-            variant="legend"
-            wrap={false}
+      <Inline justifyContent={'flex-end'} gap={8} css={{ cursor: 'pointer' }}>
+        <Tooltip label="Price impact due to the amount of liquity available in the pool.">
+          <Inline
             css={{
-              color: errorThreshold
-                ? '$textColors$error'
-                : '$textColors$secondary',
+              backgroundColor: errorThreshold
+                ? '$backgroundColors$error'
+                : '$backgroundColors$secondary',
+              padding: '$2 $4 $2 $2',
+              borderRadius: 4,
             }}
           >
-            {formattedPriceImpact}%
-          </Text>
-        </Inline>
+            <ArrowUpIcon
+              color={errorThreshold ? 'error' : 'secondary'}
+              css={{
+                transform: priceImpact < 0 ? 'rotate(180deg)' : undefined,
+              }}
+              size="medium"
+            />
+            <Text
+              variant="legend"
+              wrap={false}
+              css={{
+                color: errorThreshold
+                  ? '$textColors$error'
+                  : '$textColors$secondary',
+              }}
+            >
+              {formattedPriceImpact}%
+            </Text>
+          </Inline>
+        </Tooltip>
         <Column gap={4}>
           <Text variant="legend">${tokenAFormattedSwapValue}</Text>
           <Text variant="legend">${tokenBFormattedSwapValue}</Text>

--- a/features/swap/components/TransactionTips.tsx
+++ b/features/swap/components/TransactionTips.tsx
@@ -36,7 +36,7 @@ export const TransactionTips = ({
     tokenAmount: tokenA?.amount || 1,
   })
 
-  const { isShowing, conversionRate, conversionRateInDollar, dollarValue } =
+  const { isShowing, conversionRate, conversionRateInDollar, tokenBSwapValueUSD } =
     useTxRates({
       tokenASymbol: tokenA?.tokenSymbol,
       tokenBSymbol: tokenB?.tokenSymbol,
@@ -72,7 +72,7 @@ export const TransactionTips = ({
     </>
   )
 
-  const formattedDollarValue = dollarValueFormatterWithDecimals(dollarValue, {
+  const formattedDollarValue = dollarValueFormatterWithDecimals(tokenBSwapValueUSD, {
     includeCommaSeparation: true,
   })
 

--- a/features/swap/components/TransactionTips.tsx
+++ b/features/swap/components/TransactionTips.tsx
@@ -36,14 +36,19 @@ export const TransactionTips = ({
     tokenAmount: tokenA?.amount || 1,
   })
 
-  const { isShowing, conversionRate, conversionRateInDollar, tokenBSwapValueUSD } =
-    useTxRates({
-      tokenASymbol: tokenA?.tokenSymbol,
-      tokenBSymbol: tokenB?.tokenSymbol,
-      tokenAAmount: tokenA?.amount || 1,
-      tokenToTokenPrice,
-      isLoading: isPriceLoading,
-    })
+  const {
+    isShowing,
+    conversionRate,
+    conversionRateInDollar,
+    tokenASwapValueUSD,
+    tokenBSwapValueUSD,
+  } = useTxRates({
+    tokenASymbol: tokenA?.tokenSymbol,
+    tokenBSymbol: tokenB?.tokenSymbol,
+    tokenAAmount: tokenA?.amount || 1,
+    tokenToTokenPrice,
+    isLoading: isPriceLoading,
+  })
 
   const switchTokensButton = (
     <Button
@@ -72,9 +77,21 @@ export const TransactionTips = ({
     </>
   )
 
-  const formattedDollarValue = dollarValueFormatterWithDecimals(tokenBSwapValueUSD, {
-    includeCommaSeparation: true,
-  })
+  const priceImpact =
+    (tokenBSwapValueUSD - tokenASwapValueUSD) / tokenASwapValueUSD
+  const formattedPriceImpact = Math.round(priceImpact * 10000) / 100
+  const tokenAFormattedSwapValue = dollarValueFormatterWithDecimals(
+    tokenASwapValueUSD,
+    {
+      includeCommaSeparation: true,
+    }
+  )
+  const tokenBFormattedSwapValue = dollarValueFormatterWithDecimals(
+    tokenBSwapValueUSD,
+    {
+      includeCommaSeparation: true,
+    }
+  )
 
   if (size === 'small') {
     return (
@@ -93,7 +110,7 @@ export const TransactionTips = ({
               {transactionRates}
             </Text>
             <Text variant="caption" color="disabled" wrap={false}>
-              Swap estimate: ${formattedDollarValue}
+              Swap estimate: ${tokenBFormattedSwapValue}
             </Text>
           </Column>
         )}
@@ -112,8 +129,15 @@ export const TransactionTips = ({
           </Text>
         )}
       </StyledDivForRateWrapper>
-
-      <Text variant="legend">${formattedDollarValue}</Text>
+      <Inline justifyContent={'flex-end'} gap={12}>
+        <Button variant="secondary" css={{}}>
+          <Text variant="legend" wrap={false}>{formattedPriceImpact}%</Text>
+        </Button>
+        <Column gap={4}>
+          <Text variant="legend">${tokenAFormattedSwapValue}</Text>
+          <Text variant="legend">${tokenBFormattedSwapValue}</Text>
+        </Column>
+      </Inline>
     </StyledDivForWrapper>
   )
 }

--- a/features/swap/components/TransactionTips.tsx
+++ b/features/swap/components/TransactionTips.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowUpIcon,
   Button,
   Column,
   dollarValueFormatterWithDecimals,
@@ -79,7 +80,9 @@ export const TransactionTips = ({
 
   const priceImpact =
     (tokenBSwapValueUSD - tokenASwapValueUSD) / tokenASwapValueUSD
-  const formattedPriceImpact = Math.round(priceImpact * 10000) / 100
+  const formattedPriceImpact = Math.abs(Math.round(priceImpact * 10000) / 100)
+  const errorThreshold = priceImpact < -0.05
+
   const tokenAFormattedSwapValue = dollarValueFormatterWithDecimals(
     tokenASwapValueUSD,
     {
@@ -129,10 +132,33 @@ export const TransactionTips = ({
           </Text>
         )}
       </StyledDivForRateWrapper>
-      <Inline justifyContent={'flex-end'} gap={12}>
-        <Button variant="secondary" css={{}}>
-          <Text variant="legend" wrap={false}>{formattedPriceImpact}%</Text>
-        </Button>
+      <Inline justifyContent={'flex-end'} gap={8}>
+        <Inline
+          css={{
+            backgroundColor: errorThreshold
+              ? '$backgroundColors$error'
+              : '$backgroundColors$secondary',
+            padding: '$2 $4 $2 $2',
+            borderRadius: 4,
+          }}
+        >
+          <ArrowUpIcon
+            color={errorThreshold ? 'error' : 'secondary'}
+            css={{ transform: priceImpact < 0 ? 'rotate(180deg)' : undefined }}
+            size="medium"
+          />
+          <Text
+            variant="legend"
+            wrap={false}
+            css={{
+              color: errorThreshold
+                ? '$textColors$error'
+                : '$textColors$secondary',
+            }}
+          >
+            {formattedPriceImpact}%
+          </Text>
+        </Inline>
         <Column gap={4}>
           <Text variant="legend">${tokenAFormattedSwapValue}</Text>
           <Text variant="legend">${tokenBFormattedSwapValue}</Text>

--- a/features/swap/components/TransactionTips.tsx
+++ b/features/swap/components/TransactionTips.tsx
@@ -134,36 +134,38 @@ export const TransactionTips = ({
         )}
       </StyledDivForRateWrapper>
       <Inline justifyContent={'flex-end'} gap={8} css={{ cursor: 'pointer' }}>
-        <Tooltip label="Price impact due to the amount of liquity available in the pool.">
-          <Inline
-            css={{
-              backgroundColor: errorThreshold
-                ? '$backgroundColors$error'
-                : '$backgroundColors$secondary',
-              padding: '$2 $4 $2 $2',
-              borderRadius: 4,
-            }}
-          >
-            <ArrowUpIcon
-              color={errorThreshold ? 'error' : 'secondary'}
+        {tokenB?.tokenSymbol && (
+          <Tooltip label="Price impact due to the amount of liquity available in the pool.">
+            <Inline
               css={{
-                transform: priceImpact < 0 ? 'rotate(180deg)' : undefined,
-              }}
-              size="medium"
-            />
-            <Text
-              variant="legend"
-              wrap={false}
-              css={{
-                color: errorThreshold
-                  ? '$textColors$error'
-                  : '$textColors$secondary',
+                backgroundColor: errorThreshold
+                  ? '$backgroundColors$error'
+                  : '$backgroundColors$secondary',
+                padding: '$2 $4 $2 $2',
+                borderRadius: 4,
               }}
             >
-              {formattedPriceImpact}%
-            </Text>
-          </Inline>
-        </Tooltip>
+              <ArrowUpIcon
+                color={errorThreshold ? 'error' : 'secondary'}
+                css={{
+                  transform: priceImpact < 0 ? 'rotate(180deg)' : undefined,
+                }}
+                size="medium"
+              />
+              <Text
+                variant="legend"
+                wrap={false}
+                css={{
+                  color: errorThreshold
+                    ? '$textColors$error'
+                    : '$textColors$secondary',
+                }}
+              >
+                {formattedPriceImpact}%
+              </Text>
+            </Inline>
+          </Tooltip>
+        )}
         <Column gap={4}>
           <Text variant="legend">${tokenAFormattedSwapValue}</Text>
           <Text variant="legend">${tokenBFormattedSwapValue}</Text>

--- a/features/swap/hooks/useTxRates.ts
+++ b/features/swap/hooks/useTxRates.ts
@@ -23,7 +23,8 @@ export const useTxRates = ({
   tokenToTokenPrice,
   isLoading,
 }) => {
-  const [tokenADollarValue, fetchingTokenDollarPrice] = useTokenDollarValue(tokenASymbol)
+  const [tokenADollarValue, fetchingTokenDollarPrice] =
+    useTokenDollarValue(tokenASymbol)
 
   const [oneTokenToTokenPrice] = usePriceForOneToken({
     tokenASymbol: tokenASymbol,
@@ -57,7 +58,7 @@ export const useTxRates = ({
       : protectAgainstNaN(conversionRate * tokenBDollarValue)
   )
 
-  const tokenASwapValueUSD = (tokenADollarValue || 0) * (tokenAAmount || 0) 
+  const tokenASwapValueUSD = (tokenADollarValue || 0) * (tokenAAmount || 0)
   const tokenBSwapValueUSD =
     (tokenBDollarValue || 0) * (tokenAAmount * conversionRate || 0)
 

--- a/features/swap/hooks/useTxRates.ts
+++ b/features/swap/hooks/useTxRates.ts
@@ -44,8 +44,6 @@ export const useTxRates = ({
     tokenBSymbol: tokenBSymbol,
   })
 
-  const dollarValue = (tokenADollarPrice || 0) * (tokenAAmount || 0)
-
   const shouldShowRates =
     (tokenASymbol &&
       tokenBSymbol &&
@@ -66,18 +64,15 @@ export const useTxRates = ({
         )
   )
 
+  const [tokenBDollarValue] = useTokenDollarValue(tokenBSymbol)
   const conversionRateInDollar = usePersistance(
     isLoading || fetchingTokenDollarPrice || !shouldShowRates
       ? undefined
-      : protectAgainstNaN(
-          calculateTokenToTokenConversionDollarRate({
-            tokenAAmount,
-            conversionRate,
-            tokenADollarPrice,
-            oneTokenToTokenPrice,
-          })
-        )
+      : protectAgainstNaN(conversionRate * tokenBDollarValue)
   )
+
+  const dollarValue =
+    (tokenBDollarValue || 0) * (tokenAAmount * conversionRate || 0)
 
   return {
     isShowing: Boolean(shouldShowRates),

--- a/features/swap/hooks/useTxRates.ts
+++ b/features/swap/hooks/useTxRates.ts
@@ -16,19 +16,6 @@ function calculateTokenToTokenConversionRate({
   return tokenToTokenPrice / tokenAAmount
 }
 
-function calculateTokenToTokenConversionDollarRate({
-  conversionRate,
-  tokenADollarPrice,
-  oneTokenToTokenPrice,
-  tokenAAmount,
-}) {
-  if (tokenAAmount === 0) {
-    return tokenADollarPrice
-  }
-
-  return (tokenADollarPrice * conversionRate) / oneTokenToTokenPrice
-}
-
 export const useTxRates = ({
   tokenASymbol,
   tokenBSymbol,
@@ -36,8 +23,7 @@ export const useTxRates = ({
   tokenToTokenPrice,
   isLoading,
 }) => {
-  const [tokenADollarPrice, fetchingTokenDollarPrice] =
-    useTokenDollarValue(tokenASymbol)
+  const [_, fetchingTokenDollarPrice] = useTokenDollarValue(tokenASymbol)
 
   const [oneTokenToTokenPrice] = usePriceForOneToken({
     tokenASymbol: tokenASymbol,

--- a/features/swap/hooks/useTxRates.ts
+++ b/features/swap/hooks/useTxRates.ts
@@ -23,7 +23,7 @@ export const useTxRates = ({
   tokenToTokenPrice,
   isLoading,
 }) => {
-  const [_, fetchingTokenDollarPrice] = useTokenDollarValue(tokenASymbol)
+  const [tokenADollarValue, fetchingTokenDollarPrice] = useTokenDollarValue(tokenASymbol)
 
   const [oneTokenToTokenPrice] = usePriceForOneToken({
     tokenASymbol: tokenASymbol,
@@ -57,13 +57,15 @@ export const useTxRates = ({
       : protectAgainstNaN(conversionRate * tokenBDollarValue)
   )
 
-  const dollarValue =
+  const tokenASwapValueUSD = (tokenADollarValue || 0) * (tokenAAmount || 0) 
+  const tokenBSwapValueUSD =
     (tokenBDollarValue || 0) * (tokenAAmount * conversionRate || 0)
 
   return {
     isShowing: Boolean(shouldShowRates),
     conversionRate,
     conversionRateInDollar,
-    dollarValue,
+    tokenASwapValueUSD,
+    tokenBSwapValueUSD,
   }
 }


### PR DESCRIPTION
Fixes a critical bug by just showing the tokenB's amount and its actual liquidity. I opted for just using existing UI and convert using the second token's liquidity instead of the first token, since the second token (tokenB) is what the user actually ends up with.

https://www.notion.so/Pools-with-low-liquidity-lose-money-users-2eb52691f0424f6d960d289f49cae7e5 