### PR TITLE
remove divider at foot of navigation side bar

### DIFF
--- a/components/Layout/NavigationSidebar.tsx
+++ b/components/Layout/NavigationSidebar.tsx
@@ -255,7 +255,6 @@ export function NavigationSidebar(_: NavigationSidebarProps) {
             Dark mode
           </Button>
         </Inline>
-        <Divider offsetY="$6" />
         <Column gap={4}>
           <Button
             as="a"


### PR DESCRIPTION
This PR removes the divider at the foot of the navigation bar to better match design spe

Before: 

![image](https://user-images.githubusercontent.com/86395884/199135280-3ea894bb-a8c1-429f-bb14-0cac2643b758.png)

After:

![image](https://user-images.githubusercontent.com/86395884/199135314-ef6856bc-00d5-4f03-8b58-ba3a13cb4982.png)
